### PR TITLE
Link sales to their transactions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,6 +117,8 @@ model Transaction {
   amount      Float
   createdAt   DateTime        @default(now())
 
+  sale Sale?
+
   user User @relation(fields: [userId], references: [id])
   unit Unit @relation(fields: [unitId], references: [id])
   session CashRegisterSession? @relation(fields: [cashRegisterSessionId], references: [id])
@@ -130,6 +132,7 @@ model Sale {
   unitId    String
   sessionId String?
   couponId  String?
+  transactionId String @unique
   total     Float
   method    PaymentMethod
   createdAt DateTime      @default(now())
@@ -139,6 +142,7 @@ model Sale {
   unit   Unit       @relation(fields: [unitId], references: [id])
   coupon Coupon?    @relation(fields: [couponId], references: [id])
   session CashRegisterSession? @relation(fields: [sessionId], references: [id])
+  transaction Transaction @relation(fields: [transactionId], references: [id])
 
   @@map("sales")
 }

--- a/src/repositories/prisma/prisma-sale-repository.ts
+++ b/src/repositories/prisma/prisma-sale-repository.ts
@@ -1,5 +1,13 @@
 import { prisma } from '@/lib/prisma'
-import { Prisma, Sale, SaleItem, Service, User, Coupon } from '@prisma/client'
+import {
+  Prisma,
+  Sale,
+  SaleItem,
+  Service,
+  User,
+  Coupon,
+  Transaction,
+} from '@prisma/client'
 import { SaleRepository, DetailedSale } from '../sale-repository'
 
 export class PrismaSaleRepository implements SaleRepository {
@@ -17,6 +25,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }
@@ -35,6 +44,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }
@@ -53,6 +63,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }
@@ -71,6 +82,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }
@@ -89,6 +101,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }
@@ -107,6 +120,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }
@@ -125,6 +139,7 @@ export class PrismaSaleRepository implements SaleRepository {
         user: { include: { profile: true } },
         coupon: true,
         session: true,
+        transaction: true,
       },
     })
   }

--- a/src/repositories/sale-repository.ts
+++ b/src/repositories/sale-repository.ts
@@ -7,6 +7,7 @@ import {
   Coupon,
   Profile,
   CashRegisterSession,
+  Transaction,
 } from '@prisma/client'
 
 export type DetailedSaleItem = SaleItem & {
@@ -21,6 +22,7 @@ export type DetailedSale = Sale & {
   user: User & { profile: Profile | null }
   coupon: Coupon | null
   session: CashRegisterSession | null
+  transaction: Transaction
 }
 
 export interface SaleRepository {

--- a/src/services/sale/create-sale.ts
+++ b/src/services/sale/create-sale.ts
@@ -131,6 +131,15 @@ export class CreateSaleService {
     const calculatedTotal = tempItems.reduce((acc, i) => acc + i.price, 0)
     if (typeof total !== 'number') total = calculatedTotal
 
+    const transaction = await this.transactionRepository.create({
+      user: { connect: { id: userId } },
+      unit: { connect: { id: user?.unitId } },
+      session: { connect: { id: session.id } },
+      type: TransactionType.ADDITION,
+      description: 'Sale',
+      amount: total,
+    })
+
     const sale = await this.saleRepository.create({
       total,
       method,
@@ -139,15 +148,7 @@ export class CreateSaleService {
       session: { connect: { id: session.id } },
       items: { create: saleItems },
       coupon: couponConnect,
-    })
-
-    await this.transactionRepository.create({
-      user: { connect: { id: userId } },
-      unit: { connect: { id: user?.unitId } },
-      session: { connect: { id: session.id } },
-      type: TransactionType.ADDITION,
-      description: 'Sale',
-      amount: total,
+      transaction: { connect: { id: transaction.id } },
     })
 
     return { sale }


### PR DESCRIPTION
## Summary
- add transaction relation to Sale model
- expose transaction in Sale repository
- include transaction when querying sales
- create transaction before sale and link it

## Testing
- `npx prisma generate` *(fails: needs package install)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6b0373d0832992f896992bcd4374