### PR TITLE
Implement auto-calculated finalAmount

### DIFF
--- a/insomnia-barbershop.json
+++ b/insomnia-barbershop.json
@@ -351,7 +351,7 @@
       "url": "{{ baseURL }}/cash-session/close",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"sessionId\": \"\",\n  \"finalAmount\": 0\n}"
+        "text": "{\n  \"sessionId\": \"\"\n}"
       },
       "headers": [
         {

--- a/src/http/controllers/cash-register/close-session-controller.ts
+++ b/src/http/controllers/cash-register/close-session-controller.ts
@@ -8,7 +8,6 @@ export async function CloseSessionController(
 ) {
   const bodySchema = z.object({
     sessionId: z.string(),
-    finalAmount: z.number(),
   })
   const data = bodySchema.parse(request.body)
   const service = makeCloseSessionService()

--- a/src/services/cash-register/close-session.ts
+++ b/src/services/cash-register/close-session.ts
@@ -1,9 +1,8 @@
 import { CashRegisterRepository } from '@/repositories/cash-register-repository'
-import { CashRegisterSession } from '@prisma/client'
+import { CashRegisterSession, TransactionType } from '@prisma/client'
 
 interface CloseSessionRequest {
   sessionId: string
-  finalAmount: number
 }
 
 interface CloseSessionResponse {
@@ -13,7 +12,16 @@ interface CloseSessionResponse {
 export class CloseSessionService {
   constructor(private repository: CashRegisterRepository) {}
 
-  async execute({ sessionId, finalAmount }: CloseSessionRequest): Promise<CloseSessionResponse> {
+  async execute({ sessionId }: CloseSessionRequest): Promise<CloseSessionResponse> {
+    const sessionData = await this.repository.findById(sessionId)
+    if (!sessionData) throw new Error('Session not found')
+
+    const finalAmount = sessionData.transactions.reduce((total, transaction) => {
+      if (transaction.type === TransactionType.ADDITION) return total + transaction.amount
+      if (transaction.type === TransactionType.WITHDRAWAL) return total - transaction.amount
+      return total
+    }, 0)
+
     const session = await this.repository.close(sessionId, {
       finalAmount,
       closedAt: new Date(),


### PR DESCRIPTION
## Summary
- compute final amount automatically when closing cash session
- adjust controller and Insomnia request example

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbf8faf00832993d635cee8dbaa89