### PR TITLE
Implement auto-calculated finalAmount

### DIFF
--- a/insomnia-barbershop.json
+++ b/insomnia-barbershop.json
@@ -351,7 +351,7 @@
       "url": "{{ baseURL }}/cash-session/close",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"sessionId\": \"\",\n  \"finalAmount\": 0\n}"
+        "text": "{\n  \"sessionId\": \"\"\n}"
       },
       "headers": [
         {

--- a/src/http/controllers/cash-register/close-session-controller.ts
+++ b/src/http/controllers/cash-register/close-session-controller.ts
@@ -8,7 +8,6 @@ export async function CloseSessionController(
 ) {
   const bodySchema = z.object({
     sessionId: z.string(),
-    finalAmount: z.number(),
   })
   const data = bodySchema.parse(request.body)
   const service = makeCloseSessionService()

--- a/src/repositories/barber-users-repository.ts
+++ b/src/repositories/barber-users-repository.ts
@@ -11,4 +11,9 @@ export interface BarberUsersRepository {
   ): Promise<(User & { profile: Profile | null; unit: Unit | null }) | null>
   findByEmail(email: string): Promise<User | null>
   delete(id: string): Promise<void>
+  update(
+    id: string,
+    userData: Prisma.UserUpdateInput,
+    profileData: Prisma.ProfileUpdateInput,
+  ): Promise<{ user: User; profile: Profile | null }>
 }

--- a/src/repositories/prisma/prisma-barber-users-repository.ts
+++ b/src/repositories/prisma/prisma-barber-users-repository.ts
@@ -34,4 +34,23 @@ export class PrismaBarberUsersRepository implements BarberUsersRepository {
   async delete(id: string): Promise<void> {
     await prisma.user.delete({ where: { id } })
   }
+
+  async update(
+    id: string,
+    userData: Prisma.UserUpdateInput,
+    profileData: Prisma.ProfileUpdateInput,
+  ): Promise<{ user: User; profile: Profile | null }> {
+    const user = await prisma.user.update({
+      where: { id },
+      data: {
+        ...userData,
+        profile: {
+          update: profileData,
+        },
+      },
+      include: { profile: true },
+    })
+
+    return { user, profile: user.profile }
+  }
 }

--- a/src/services/barber-user/update-user.ts
+++ b/src/services/barber-user/update-user.ts
@@ -26,16 +26,10 @@ export class UpdateUserService {
       throw new Error('User not found')
     }
 
-    await this.repository.delete(data.id)
-    const { user, profile } = await this.repository.create(
+    const { user, profile } = await this.repository.update(
+      data.id,
       {
-        id: data.id,
         name: data.name,
-        email: existing.email,
-        password: existing.password,
-        active: existing.active,
-        organization: { connect: { id: existing.organizationId } },
-        unit: { connect: { id: existing.unitId } },
       },
       {
         phone: data.phone,

--- a/src/services/cash-register/close-session.ts
+++ b/src/services/cash-register/close-session.ts
@@ -1,9 +1,8 @@
 import { CashRegisterRepository } from '@/repositories/cash-register-repository'
-import { CashRegisterSession } from '@prisma/client'
+import { CashRegisterSession, TransactionType } from '@prisma/client'
 
 interface CloseSessionRequest {
   sessionId: string
-  finalAmount: number
 }
 
 interface CloseSessionResponse {
@@ -13,7 +12,16 @@ interface CloseSessionResponse {
 export class CloseSessionService {
   constructor(private repository: CashRegisterRepository) {}
 
-  async execute({ sessionId, finalAmount }: CloseSessionRequest): Promise<CloseSessionResponse> {
+  async execute({ sessionId }: CloseSessionRequest): Promise<CloseSessionResponse> {
+    const sessionData = await this.repository.findById(sessionId)
+    if (!sessionData) throw new Error('Session not found')
+
+    const finalAmount = sessionData.transactions.reduce((total, transaction) => {
+      if (transaction.type === TransactionType.ADDITION) return total + transaction.amount
+      if (transaction.type === TransactionType.WITHDRAWAL) return total - transaction.amount
+      return total
+    }, 0)
+
     const session = await this.repository.close(sessionId, {
       finalAmount,
       closedAt: new Date(),


### PR DESCRIPTION
## Summary
- compute final amount automatically when closing cash session
- adjust controller and Insomnia request example
- add proper BarberUser update using Prisma update

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbf8faf00832993d635cee8dbaa89