### PR TITLE
Link coupon to unit

### DIFF
--- a/prisma/migrations/20250614000000_add_unit_to_coupon/migration.sql
+++ b/prisma/migrations/20250614000000_add_unit_to_coupon/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `coupons` ADD COLUMN `unitId` VARCHAR(191);
+
+-- AddForeignKey
+ALTER TABLE `coupons` ADD CONSTRAINT `coupons_unitId_fkey` FOREIGN KEY (`unitId`) REFERENCES `units`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,9 +195,12 @@ model Coupon {
   discountType DiscountType @default(PERCENTAGE)
   imageUrl     String?
   quantity     Int          @default(0)
+  unitId       String
   createdAt    DateTime     @default(now())
   sales        Sale[]
   saleItems    SaleItem[]
+
+  unit Unit @relation(fields: [unitId], references: [id])
 
   @@map("coupons")
 }

--- a/src/http/controllers/coupon/create-coupon-controller.ts
+++ b/src/http/controllers/coupon/create-coupon-controller.ts
@@ -13,6 +13,7 @@ export async function CreateCouponController(
     discountType: z.enum(['PERCENTAGE', 'VALUE']).default('PERCENTAGE'),
     imageUrl: z.string().optional(),
     quantity: z.number().optional(),
+    unitId: z.string(),
   })
   const data = bodySchema.parse(request.body)
   const service = makeCreateCouponService()

--- a/src/repositories/prisma/seed.ts
+++ b/src/repositories/prisma/seed.ts
@@ -145,6 +145,7 @@ async function main() {
       discount: 5,
       discountType: DiscountType.VALUE,
       quantity: 10,
+      unit: { connect: { id: mainUnit.id } },
     },
   })
 
@@ -229,6 +230,7 @@ async function main() {
       discount: 10,
       discountType: DiscountType.PERCENTAGE,
       quantity: 10,
+      unit: { connect: { id: mainUnit.id } },
     },
   })
 

--- a/src/services/coupon/create-coupon.ts
+++ b/src/services/coupon/create-coupon.ts
@@ -8,6 +8,7 @@ interface CreateCouponRequest {
   discountType: 'PERCENTAGE' | 'VALUE'
   imageUrl?: string | null
   quantity?: number
+  unitId: string
 }
 
 interface CreateCouponResponse {
@@ -18,7 +19,15 @@ export class CreateCouponService {
   constructor(private repository: CouponRepository) {}
 
   async execute(data: CreateCouponRequest): Promise<CreateCouponResponse> {
-    const coupon = await this.repository.create(data)
+    const coupon = await this.repository.create({
+      code: data.code,
+      description: data.description,
+      discount: data.discount,
+      discountType: data.discountType,
+      imageUrl: data.imageUrl,
+      quantity: data.quantity,
+      unit: { connect: { id: data.unitId } },
+    })
     return { coupon }
   }
 }


### PR DESCRIPTION
## Summary
- add `unitId` link in `Coupon` model and create migration
- require `unitId` when creating coupons via controller & service
- seed sample coupons with unit link

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5f4516d88329a408c745c7132b7b