### PR TITLE
Implement transaction and unit enhancements

### DIFF
--- a/insomnia-barbershop.json
+++ b/insomnia-barbershop.json
@@ -435,7 +435,7 @@
       "url": "{{ baseURL }}/transactions",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"userId\": \"\",\n  \"unitId\": \"\",\n  \"type\": \"ADDITION\",\n  \"description\": \"\",\n  \"amount\": 0\n}"
+        "text": "{\n  \"userId\": \"\",\n  \"unitId\": \"\",\n  \"affectedUserId\": \"\",\n  \"type\": \"ADDITION\",\n  \"description\": \"\",\n  \"amount\": 0\n}"
       },
       "headers": [
         {
@@ -569,7 +569,7 @@
       "url": "{{ baseURL }}/units",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"name\": \"\",\n  \"slug\": \"\",\n  \"organizationId\": \"\",\n  \"totalBalance\": 0\n}"
+        "text": "{\n  \"name\": \"\",\n  \"slug\": \"\",\n  \"organizationId\": \"\",\n  \"totalBalance\": 0,\n  \"allowsLoan\": false\n}"
       },
       "headers": [
         {
@@ -619,7 +619,7 @@
       "url": "{{ baseURL }}/units/{{ unitId }}",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"name\": \"New Unit\",\n  \"slug\": \"new-unit\"\n}"
+        "text": "{\n  \"name\": \"New Unit\",\n  \"slug\": \"new-unit\",\n  \"allowsLoan\": false\n}"
       },
       "headers": [
         {

--- a/prisma/migrations/20250617000000_add_allowsLoan_affected_user/migration.sql
+++ b/prisma/migrations/20250617000000_add_allowsLoan_affected_user/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE `units` ADD COLUMN `allowsLoan` BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE `transactions` ADD COLUMN `affectedUserId` VARCHAR(191);
+
+-- AddForeignKey
+ALTER TABLE `transactions` ADD CONSTRAINT `transactions_affectedUserId_fkey` FOREIGN KEY (`affectedUserId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   clientSales         Sale[]                @relation("SaleClient")
   saleItems           SaleItem[]
   transactions        Transaction[]
+  affectedTransactions Transaction[] @relation("AffectedUser")
   sessions            CashRegisterSession[]
   passwordResetTokens PasswordResetToken[]
   ownedOrganizations  Organization[]        @relation("OrganizationOwner")
@@ -112,6 +113,7 @@ model Service {
 model Transaction {
   id                    String          @id @default(uuid())
   userId                String
+  affectedUserId        String?
   unitId                String
   cashRegisterSessionId String?
   type                  TransactionType
@@ -122,6 +124,7 @@ model Transaction {
   sale Sale?
 
   user    User                 @relation(fields: [userId], references: [id])
+  affectedUser User?           @relation("AffectedUser", fields: [affectedUserId], references: [id])
   unit    Unit                 @relation(fields: [unitId], references: [id])
   session CashRegisterSession? @relation(fields: [cashRegisterSessionId], references: [id])
 
@@ -238,6 +241,7 @@ model Unit {
   slug           String                @unique
   organizationId String
   totalBalance   Float                 @default(0)
+  allowsLoan     Boolean               @default(false)
   services       Service[]
   appointments   Appointment[]
   sales          Sale[]

--- a/src/http/controllers/barber-user/create-user-controller.ts
+++ b/src/http/controllers/barber-user/create-user-controller.ts
@@ -24,6 +24,12 @@ export async function CreateBarberUserController(
   const data = bodySchema.parse(request.body)
   const service = makeRegisterUserService()
   const userToken = request.user as UserToken
+  if (
+    (data.role === 'ADMIN' || data.role === 'OWNER') &&
+    userToken.role !== 'ADMIN'
+  ) {
+    return reply.status(403).send({ message: 'Unauthorized' })
+  }
   let unitId = userToken.unitId
   if (userToken.role === 'ADMIN') {
     unitId = data.unitId ?? unitId

--- a/src/http/controllers/barber-user/update-user-controller.ts
+++ b/src/http/controllers/barber-user/update-user-controller.ts
@@ -30,7 +30,12 @@ export async function UpdateBarberUserController(
   const { id } = paramsSchema.parse(request.params)
   const data = bodySchema.parse(request.body)
   const service = makeUpdateUserService()
-  const userToken = request.user as { sub: string; organizationId: string; unitId: string; role: Role }
+  const userToken = request.user as {
+    sub: string
+    organizationId: string
+    unitId: string
+    role: Role
+  }
   const result = await service.execute({ id, ...data })
 
   if (id === userToken.sub && (data.unitId || data.role)) {

--- a/src/http/controllers/register-user-controller.ts
+++ b/src/http/controllers/register-user-controller.ts
@@ -19,6 +19,7 @@ export async function registerUser(
     pix: z.string(),
     role: z.nativeEnum(Role),
     organizationId: z.string(),
+    unitId: z.string(),
   })
 
   const data = registerBodySchema.parse(request.body)

--- a/src/http/controllers/register-user-controller.ts
+++ b/src/http/controllers/register-user-controller.ts
@@ -23,6 +23,10 @@ export async function registerUser(
 
   const data = registerBodySchema.parse(request.body)
 
+  if (data.role === 'ADMIN' || data.role === 'OWNER') {
+    return replay.status(403).send({ message: 'Unauthorized role' })
+  }
+
   try {
     const registerService = makeRegisterService()
 

--- a/src/http/controllers/set-user-unit-controller.ts
+++ b/src/http/controllers/set-user-unit-controller.ts
@@ -28,5 +28,10 @@ export async function SetUserUnitController(
     throw error
   }
 
-  return reply.status(200).send()
+  const token = await reply.jwtSign(
+    { unitId, organizationId: user.organizationId, role: user.role },
+    { sign: { sub: user.sub } },
+  )
+
+  return reply.status(200).send({ token })
 }

--- a/src/http/controllers/transaction/create-transaction-controller.ts
+++ b/src/http/controllers/transaction/create-transaction-controller.ts
@@ -15,12 +15,7 @@ export async function CreateTransactionController(
   })
   const data = bodySchema.parse(request.body)
   const user = request.user as UserToken
-  if (
-    data.affectedUserId &&
-    data.affectedUserId !== user.sub &&
-    user.role !== 'ADMIN' &&
-    user.role !== 'OWNER'
-  ) {
+  if (data.affectedUserId && user.role !== 'ADMIN' && user.role !== 'OWNER') {
     return reply.status(403).send({ message: 'Unauthorized' })
   }
   const userId = user.sub

--- a/src/http/controllers/transaction/create-transaction-controller.ts
+++ b/src/http/controllers/transaction/create-transaction-controller.ts
@@ -1,6 +1,7 @@
 import { makeCreateTransaction } from '@/services/@factories/transaction/make-create-transaction'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
+import { UserToken } from '../authenticate-controller'
 
 export async function CreateTransactionController(
   request: FastifyRequest,
@@ -10,13 +11,24 @@ export async function CreateTransactionController(
     type: z.enum(['ADDITION', 'WITHDRAWAL']),
     description: z.string(),
     amount: z.number(),
+    affectedUserId: z.string().optional(),
   })
   const data = bodySchema.parse(request.body)
-  const userId = request.user.sub
+  const user = request.user as UserToken
+  if (
+    data.affectedUserId &&
+    data.affectedUserId !== user.sub &&
+    user.role !== 'ADMIN' &&
+    user.role !== 'OWNER'
+  ) {
+    return reply.status(403).send({ message: 'Unauthorized' })
+  }
+  const userId = user.sub
   const service = makeCreateTransaction()
   const { transaction, surplusValue } = await service.execute({
     ...data,
     userId,
+    affectedUserId: data.affectedUserId,
   })
   return reply.status(201).send({ transaction, surplusValue })
 }

--- a/src/http/controllers/unit/create-unit-controller.ts
+++ b/src/http/controllers/unit/create-unit-controller.ts
@@ -11,6 +11,7 @@ export async function CreateUnitController(
     name: z.string(),
     slug: z.string(),
     organizationId: z.string().optional(),
+    allowsLoan: z.boolean().optional(),
   })
   const data = bodySchema.parse(request.body)
   const service = makeCreateUnitService()

--- a/src/http/controllers/unit/update-unit-controller.ts
+++ b/src/http/controllers/unit/update-unit-controller.ts
@@ -7,9 +7,15 @@ export async function UpdateUnitController(
   reply: FastifyReply,
 ) {
   const bodySchema = z.object({
-    name: z.string(),
+    name: z.string().optional(),
     slug: z.string().optional(),
-    allowsLoan: z.boolean().optional(),
+    allowsLoan: z
+      .union([z.boolean(), z.string()])
+      .transform((val) => {
+        if (typeof val === 'boolean') return val
+        return val === 'true'
+      })
+      .optional(),
   })
   const paramsSchema = z.object({
     id: z.string(),

--- a/src/http/controllers/unit/update-unit-controller.ts
+++ b/src/http/controllers/unit/update-unit-controller.ts
@@ -9,13 +9,14 @@ export async function UpdateUnitController(
   const bodySchema = z.object({
     name: z.string(),
     slug: z.string().optional(),
+    allowsLoan: z.boolean().optional(),
   })
   const paramsSchema = z.object({
     id: z.string(),
   })
-  const { name, slug } = bodySchema.parse(request.body)
+  const { name, slug, allowsLoan } = bodySchema.parse(request.body)
   const { id } = paramsSchema.parse(request.params)
   const service = makeUpdateUnitService()
-  const { unit } = await service.execute({ id, name, slug })
+  const { unit } = await service.execute({ id, name, slug, allowsLoan })
   return reply.status(200).send(unit)
 }

--- a/src/services/transaction/create-transaction.ts
+++ b/src/services/transaction/create-transaction.ts
@@ -2,7 +2,7 @@ import { BarberUsersRepository } from '@/repositories/barber-users-repository'
 import { CashRegisterRepository } from '@/repositories/cash-register-repository'
 import { TransactionRepository } from '@/repositories/transaction-repository'
 import { ProfilesRepository } from '@/repositories/profiles-repository'
-import { Transaction, TransactionType } from '@prisma/client'
+import { Transaction, TransactionType, User } from '@prisma/client'
 import { UnitRepository } from '@/repositories/unit-repository'
 import { OrganizationRepository } from '@/repositories/organization-repository'
 
@@ -59,7 +59,9 @@ export class CreateTransactionService {
       amount: data.amount,
       session: { connect: { id: session.id } },
     })
+
     let surplusValue: number | undefined
+
     const increment = data.type === 'ADDITION' ? data.amount : -data.amount
     if (data.type === 'WITHDRAWAL' && data.amount < 0) {
       throw new Error('Negative values ​​cannot be passed on withdrawals')
@@ -67,19 +69,23 @@ export class CreateTransactionService {
     if (data.type === 'ADDITION' && data.amount < 0) {
       throw new Error('Negative values ​​cannot be passed on additions')
     }
+
     const effectiveUser = affectedUser ?? user
+    const balanceUnit = effectiveUser.unit?.totalBalance ?? 0
+    const balanceUser = effectiveUser.profile?.totalBalance ?? 0
+
     if (increment < 0) {
       // if (affectedUser) {
-      const balanceUnit = effectiveUser.unit?.totalBalance ?? 0
-      const balanceUser = effectiveUser.profile?.totalBalance ?? 0
       surplusValue =
         -increment > balanceUser
           ? balanceUser < 0
             ? increment
             : balanceUser - -increment
           : undefined
+
       const remainingBalance =
         balanceUser > 0 ? balanceUser - -increment : increment
+
       if (remainingBalance < 0) {
         if (!effectiveUser.unit?.allowsLoan) {
           throw new Error('Insufficient balance for withdrawal')
@@ -106,30 +112,36 @@ export class CreateTransactionService {
           increment,
         )
       }
-      // }
-      // else {
-      //   const balanceUnit = user.unit?.totalBalance ?? 0
-      //   if (-increment > balanceUnit && !user.unit?.allowsLoan) {
-      //     throw new Error('Withdrawal amount greater than unit balance')
-      //   }
-      //   await this.unitRepository.incrementBalance(user.unitId, increment)
-      //   await this.organizationRepository.incrementBalance(
-      //     user.organizationId,
-      //     increment,
-      //   )
-      // }
     } else {
-      if (affectedUser) {
+      if (balanceUser < 0) {
+        const remainingBalance = balanceUser - increment
+        const valueForPay = remainingBalance < 0 ? increment : balanceUser
+        await this.unitRepository.incrementBalance(
+          effectiveUser.unitId,
+          valueForPay,
+        )
+        await this.organizationRepository.incrementBalance(
+          effectiveUser.organizationId,
+          valueForPay,
+        )
         await this.profileRepository.incrementBalance(
-          affectedUser.id,
+          effectiveUser.id,
+          valueForPay,
+        )
+      } else {
+        await this.unitRepository.incrementBalance(
+          effectiveUser.unitId,
+          increment,
+        )
+        await this.organizationRepository.incrementBalance(
+          effectiveUser.organizationId,
+          increment,
+        )
+        await this.profileRepository.incrementBalance(
+          effectiveUser.id,
           increment,
         )
       }
-      await this.unitRepository.incrementBalance(user.unitId, increment)
-      await this.organizationRepository.incrementBalance(
-        user.organizationId,
-        increment,
-      )
     }
     return { transaction, surplusValue }
   }

--- a/src/services/transaction/create-transaction.ts
+++ b/src/services/transaction/create-transaction.ts
@@ -2,7 +2,7 @@ import { BarberUsersRepository } from '@/repositories/barber-users-repository'
 import { CashRegisterRepository } from '@/repositories/cash-register-repository'
 import { TransactionRepository } from '@/repositories/transaction-repository'
 import { ProfilesRepository } from '@/repositories/profiles-repository'
-import { Transaction, TransactionType, User } from '@prisma/client'
+import { Transaction, TransactionType } from '@prisma/client'
 import { UnitRepository } from '@/repositories/unit-repository'
 import { OrganizationRepository } from '@/repositories/organization-repository'
 
@@ -59,89 +59,91 @@ export class CreateTransactionService {
       amount: data.amount,
       session: { connect: { id: session.id } },
     })
-
     let surplusValue: number | undefined
-
-    const increment = data.type === 'ADDITION' ? data.amount : -data.amount
-    if (data.type === 'WITHDRAWAL' && data.amount < 0) {
-      throw new Error('Negative values ​​cannot be passed on withdrawals')
-    }
-    if (data.type === 'ADDITION' && data.amount < 0) {
-      throw new Error('Negative values ​​cannot be passed on additions')
-    }
-
-    const effectiveUser = affectedUser ?? user
-    const balanceUnit = effectiveUser.unit?.totalBalance ?? 0
-    const balanceUser = effectiveUser.profile?.totalBalance ?? 0
-
-    if (increment < 0) {
-      // if (affectedUser) {
-      surplusValue =
-        -increment > balanceUser
-          ? balanceUser < 0
-            ? increment
-            : balanceUser - -increment
-          : undefined
-
-      const remainingBalance =
-        balanceUser > 0 ? balanceUser - -increment : increment
-
-      if (remainingBalance < 0) {
-        if (!effectiveUser.unit?.allowsLoan) {
-          throw new Error('Insufficient balance for withdrawal')
-        }
-        const remainingBalanceRelative = -remainingBalance
-        if (remainingBalanceRelative > balanceUnit) {
-          throw new Error('Withdrawal amount greater than unit balance')
-        }
-        await this.profileRepository.incrementBalance(
-          effectiveUser.id,
-          increment,
-        )
-        await this.unitRepository.incrementBalance(
-          effectiveUser.unitId,
-          remainingBalance,
-        )
-        await this.organizationRepository.incrementBalance(
-          effectiveUser.organizationId,
-          remainingBalance,
-        )
-      } else {
-        await this.profileRepository.incrementBalance(
-          effectiveUser.id,
-          increment,
-        )
+    try {
+      const increment = data.type === 'ADDITION' ? data.amount : -data.amount
+      if (data.type === 'WITHDRAWAL' && data.amount < 0) {
+        throw new Error('Negative values ​​cannot be passed on withdrawals')
       }
-    } else {
-      if (balanceUser < 0) {
-        const remainingBalance = balanceUser - increment
-        const valueForPay = remainingBalance < 0 ? increment : balanceUser
-        await this.unitRepository.incrementBalance(
-          effectiveUser.unitId,
-          valueForPay,
-        )
-        await this.organizationRepository.incrementBalance(
-          effectiveUser.organizationId,
-          valueForPay,
-        )
-        await this.profileRepository.incrementBalance(
-          effectiveUser.id,
-          valueForPay,
-        )
-      } else {
-        await this.unitRepository.incrementBalance(
-          effectiveUser.unitId,
-          increment,
-        )
-        await this.organizationRepository.incrementBalance(
-          effectiveUser.organizationId,
-          increment,
-        )
-        await this.profileRepository.incrementBalance(
-          effectiveUser.id,
-          increment,
-        )
+      if (data.type === 'ADDITION' && data.amount < 0) {
+        throw new Error('Negative values ​​cannot be passed on additions')
       }
+
+      const effectiveUser = affectedUser ?? user
+      const balanceUnit = effectiveUser.unit?.totalBalance ?? 0
+      const balanceUser = effectiveUser.profile?.totalBalance ?? 0
+
+      if (increment < 0) {
+        surplusValue =
+          -increment > balanceUser
+            ? balanceUser < 0
+              ? increment
+              : balanceUser - -increment
+            : undefined
+
+        const remainingBalance =
+          balanceUser > 0 ? balanceUser - -increment : increment
+
+        if (remainingBalance < 0) {
+          if (!effectiveUser.unit?.allowsLoan) {
+            throw new Error('Insufficient balance for withdrawal')
+          }
+          const remainingBalanceRelative = -remainingBalance
+          if (remainingBalanceRelative > balanceUnit) {
+            throw new Error('Withdrawal amount greater than unit balance')
+          }
+          await this.profileRepository.incrementBalance(
+            effectiveUser.id,
+            increment,
+          )
+          await this.unitRepository.incrementBalance(
+            effectiveUser.unitId,
+            remainingBalance,
+          )
+          await this.organizationRepository.incrementBalance(
+            effectiveUser.organizationId,
+            remainingBalance,
+          )
+        } else {
+          await this.profileRepository.incrementBalance(
+            effectiveUser.id,
+            increment,
+          )
+        }
+      } else {
+        if (balanceUser < 0) {
+          const remainingBalance = balanceUser - increment
+          const valueForPay = remainingBalance < 0 ? increment : balanceUser
+          await this.unitRepository.incrementBalance(
+            effectiveUser.unitId,
+            valueForPay,
+          )
+          await this.organizationRepository.incrementBalance(
+            effectiveUser.organizationId,
+            valueForPay,
+          )
+          await this.profileRepository.incrementBalance(
+            effectiveUser.id,
+            valueForPay,
+          )
+        } else {
+          await this.unitRepository.incrementBalance(
+            effectiveUser.unitId,
+            increment,
+          )
+          await this.organizationRepository.incrementBalance(
+            effectiveUser.organizationId,
+            increment,
+          )
+          await this.profileRepository.incrementBalance(
+            effectiveUser.id,
+            increment,
+          )
+        }
+      }
+    } catch (error) {
+      await this.repository.delete(transaction.id)
+      throw error
     }
     return { transaction, surplusValue }
   }

--- a/src/services/unit/create-unit.ts
+++ b/src/services/unit/create-unit.ts
@@ -6,6 +6,7 @@ interface CreateUnitRequest {
   name: string
   slug: string
   organizationId?: string
+  allowsLoan?: boolean
   userToken: UserToken
 }
 
@@ -28,6 +29,7 @@ export class CreateUnitService {
     const unit = await this.repository.create({
       name: data.name,
       slug: data.slug,
+      allowsLoan: data.allowsLoan ?? false,
       organization: { connect: { id: organizationId } },
     })
     return { unit }

--- a/src/services/unit/update-unit.ts
+++ b/src/services/unit/update-unit.ts
@@ -3,7 +3,7 @@ import { Unit } from '@prisma/client'
 
 interface UpdateUnitRequest {
   id: string
-  name: string
+  name?: string
   slug?: string
   allowsLoan?: boolean
 }

--- a/src/services/unit/update-unit.ts
+++ b/src/services/unit/update-unit.ts
@@ -5,6 +5,7 @@ interface UpdateUnitRequest {
   id: string
   name: string
   slug?: string
+  allowsLoan?: boolean
 }
 
 interface UpdateUnitResponse {
@@ -15,10 +16,11 @@ export class UpdateUnitService {
   constructor(private repository: UnitRepository) {}
 
   async execute(data: UpdateUnitRequest): Promise<UpdateUnitResponse> {
-    const { id, name, slug } = data
+    const { id, name, slug, allowsLoan } = data
     const unit = await this.repository.update(id, {
       name,
       ...(slug ? { slug } : {}),
+      ...(allowsLoan !== undefined ? { allowsLoan } : {}),
     })
     return { unit }
   }


### PR DESCRIPTION
## Summary
- add `allowsLoan` option to units and relation for affected transactions
- allow admin-only creation of owner/admin users
- handle affected user in transaction creation
- include `affectedUserId` in transactions
- return new JWT when updating unit or role
- support `allowsLoan` field on unit creation/update

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684dee9e772c83299cfbac5753316bf1