### PR TITLE
Add pending payment support

### DIFF
--- a/insomnia-barbershop.json
+++ b/insomnia-barbershop.json
@@ -503,7 +503,7 @@
       "url": "{{ baseURL }}/sales",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"method\": \"CASH\",\n  \"items\": [\n    {\n      \"serviceId\": \"\",\n      \"quantity\": 1,\n      \"barberId\": \"\",\n      \"couponCode\": \"\",\n      \"price\": 0\n    }\n  ],\n  \"clientId\": \"\"\n}"
+        "text": "{\n  \"method\": \"CASH\",\n  \"items\": [\n    {\n      \"serviceId\": \"\",\n      \"quantity\": 1,\n      \"barberId\": \"\",\n      \"couponCode\": \"\",\n      \"price\": 0\n    }\n  ],\n  \"clientId\": \"\",\n  \"paymentStatus\": \"PAID\"\n}"
       },
       "headers": [
         {
@@ -524,6 +524,28 @@
       "method": "GET",
       "url": "{{ baseURL }}/sales",
       "headers": [
+        {
+          "name": "Authorization",
+          "value": "Bearer {{ token }}"
+        }
+      ]
+    },
+    {
+      "_id": "req_set_sale_status",
+      "_type": "request",
+      "parentId": "fld_sales",
+      "name": "Set sale status",
+      "method": "PATCH",
+      "url": "{{ baseURL }}/sales/{{ saleId }}/status",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"paymentStatus\": \"PAID\"\n}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        },
         {
           "name": "Authorization",
           "value": "Bearer {{ token }}"

--- a/prisma/migrations/20250619000000_add_payment_status_to_sale/migration.sql
+++ b/prisma/migrations/20250619000000_add_payment_status_to_sale/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `sales` ADD COLUMN `paymentStatus` ENUM('PAID', 'PENDING') NOT NULL DEFAULT 'PAID';
+ALTER TABLE `sales` MODIFY `transactionId` VARCHAR(191) NULL;
+ALTER TABLE `sales` DROP INDEX `sales_transactionId_key`;
+ALTER TABLE `sales` ADD CONSTRAINT `sales_transactionId_key` UNIQUE (`transactionId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,11 @@ enum DiscountType {
   VALUE
 }
 
+enum PaymentStatus {
+  PAID
+  PENDING
+}
+
 model User {
   id                   String                @id @default(uuid())
   name                 String
@@ -153,9 +158,10 @@ model Sale {
   unitId        String
   sessionId     String?
   couponId      String?
-  transactionId String        @unique
+  transactionId String?       @unique
   total         Float
   method        PaymentMethod
+  paymentStatus PaymentStatus @default(PAID)
   createdAt     DateTime      @default(now())
 
   user        User                 @relation(fields: [userId], references: [id])
@@ -164,7 +170,7 @@ model Sale {
   unit        Unit                 @relation(fields: [unitId], references: [id])
   coupon      Coupon?              @relation(fields: [couponId], references: [id])
   session     CashRegisterSession? @relation(fields: [sessionId], references: [id])
-  transaction Transaction          @relation(fields: [transactionId], references: [id])
+  transaction Transaction?         @relation(fields: [transactionId], references: [id])
 
   @@map("sales")
 }

--- a/src/http/controllers/sale/create-sale-controller.ts
+++ b/src/http/controllers/sale/create-sale-controller.ts
@@ -20,6 +20,7 @@ export async function CreateSaleController(
     ),
     clientId: z.string(),
     couponCode: z.string().optional(),
+    paymentStatus: z.enum(['PAID', 'PENDING']).optional().default('PAID'),
   })
   const data = bodySchema.parse(request.body)
   const userId = request.user.sub

--- a/src/http/controllers/sale/route.ts
+++ b/src/http/controllers/sale/route.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from 'fastify'
 import { CreateSaleController } from './create-sale-controller'
 import { ListSalesController } from './list-sales-controller'
 import { GetSaleController } from './get-sale-controller'
+import { SetSaleStatusController } from './set-sale-status-controller'
 
 export async function saleRoute(app: FastifyInstance) {
   app.addHook('onRequest', verifyJWT)
@@ -10,4 +11,5 @@ export async function saleRoute(app: FastifyInstance) {
   app.post('/sales', CreateSaleController)
   app.get('/sales', ListSalesController)
   app.get('/sales/:id', GetSaleController)
+  app.patch('/sales/:id/status', SetSaleStatusController)
 }

--- a/src/http/controllers/sale/set-sale-status-controller.ts
+++ b/src/http/controllers/sale/set-sale-status-controller.ts
@@ -1,0 +1,23 @@
+import { makeSetSaleStatus } from '@/services/@factories/sale/make-set-sale-status'
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+
+export async function SetSaleStatusController(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const paramsSchema = z.object({ id: z.string() })
+  const bodySchema = z.object({
+    paymentStatus: z.enum(['PAID', 'PENDING']),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const { paymentStatus } = bodySchema.parse(request.body)
+  const userId = request.user.sub
+  const service = makeSetSaleStatus()
+  const { sale } = await service.execute({
+    saleId: id,
+    userId,
+    paymentStatus,
+  })
+  return reply.status(200).send(sale)
+}

--- a/src/repositories/prisma/prisma-sale-repository.ts
+++ b/src/repositories/prisma/prisma-sale-repository.ts
@@ -66,6 +66,31 @@ export class PrismaSaleRepository implements SaleRepository {
     })
   }
 
+  async update(
+    id: string,
+    data: Prisma.SaleUpdateInput,
+  ): Promise<DetailedSale> {
+    return prisma.sale.update({
+      where: { id },
+      data,
+      include: {
+        items: {
+          include: {
+            service: true,
+            product: true,
+            barber: { include: { profile: true } },
+            coupon: true,
+          },
+        },
+        user: { include: { profile: true } },
+        client: { include: { profile: true } },
+        coupon: true,
+        session: true,
+        transaction: true,
+      },
+    })
+  }
+
   async findManyByDateRange(start: Date, end: Date): Promise<DetailedSale[]> {
     return prisma.sale.findMany({
       where: { createdAt: { gte: start, lte: end } },

--- a/src/repositories/prisma/seed.ts
+++ b/src/repositories/prisma/seed.ts
@@ -3,6 +3,7 @@ import {
   PrismaClient,
   Role,
   PaymentMethod,
+  PaymentStatus,
   TransactionType,
   DiscountType,
 } from '@prisma/client'
@@ -257,6 +258,7 @@ async function main() {
       session: { connect: { id: cashSession.id } },
       total: 35,
       method: PaymentMethod.CASH,
+      paymentStatus: PaymentStatus.PAID,
       items: {
         create: [
           {
@@ -279,6 +281,27 @@ async function main() {
         ],
       },
       transaction: { connect: { id: transaction.id } },
+    },
+  })
+  const pendingSale = await prisma.sale.create({
+    data: {
+      user: { connect: { id: admin.id } },
+      client: { connect: { id: client.id } },
+      unit: { connect: { id: mainUnit.id } },
+      total: 20,
+      method: PaymentMethod.CASH,
+      paymentStatus: PaymentStatus.PENDING,
+      items: {
+        create: [
+          {
+            serviceId: haircut.id,
+            quantity: 1,
+            barberId: barber.id,
+            price: 20,
+            porcentagemBarbeiro: 70,
+          },
+        ],
+      },
     },
   })
   await prisma.product.update({
@@ -328,6 +351,7 @@ async function main() {
     appointment,
     cashSession,
     sale,
+    pendingSale,
     itemCoupon,
     owner2,
   })

--- a/src/repositories/sale-repository.ts
+++ b/src/repositories/sale-repository.ts
@@ -36,6 +36,7 @@ export interface SaleRepository {
   create(data: Prisma.SaleCreateInput): Promise<DetailedSale>
   findMany(where?: Prisma.SaleWhereInput): Promise<DetailedSale[]>
   findById(id: string): Promise<DetailedSale | null>
+  update(id: string, data: Prisma.SaleUpdateInput): Promise<DetailedSale>
   findManyByDateRange(start: Date, end: Date): Promise<DetailedSale[]>
   findManyByUser(userId: string): Promise<DetailedSale[]>
   findManyByBarber(barberId: string): Promise<DetailedSale[]>

--- a/src/services/@factories/sale/make-set-sale-status.ts
+++ b/src/services/@factories/sale/make-set-sale-status.ts
@@ -1,0 +1,27 @@
+import { PrismaSaleRepository } from '@/repositories/prisma/prisma-sale-repository'
+import { PrismaBarberUsersRepository } from '@/repositories/prisma/prisma-barber-users-repository'
+import { PrismaCashRegisterRepository } from '@/repositories/prisma/prisma-cash-register-repository'
+import { PrismaTransactionRepository } from '@/repositories/prisma/prisma-transaction-repository'
+import { PrismaOrganizationRepository } from '@/repositories/prisma/prisma-organization-repository'
+import { PrismaProfilesRepository } from '@/repositories/prisma/prisma-profile-repository'
+import { PrismaUnitRepository } from '@/repositories/prisma/prisma-unit-repository'
+import { SetSaleStatusService } from '@/services/sale/set-sale-status'
+
+export function makeSetSaleStatus() {
+  const saleRepository = new PrismaSaleRepository()
+  const barberUserRepository = new PrismaBarberUsersRepository()
+  const cashRegisterRepository = new PrismaCashRegisterRepository()
+  const transactionRepository = new PrismaTransactionRepository()
+  const organizationRepository = new PrismaOrganizationRepository()
+  const profileRepository = new PrismaProfilesRepository()
+  const unitRepository = new PrismaUnitRepository()
+  return new SetSaleStatusService(
+    saleRepository,
+    barberUserRepository,
+    cashRegisterRepository,
+    transactionRepository,
+    organizationRepository,
+    profileRepository,
+    unitRepository,
+  )
+}

--- a/src/services/sale/set-sale-status.ts
+++ b/src/services/sale/set-sale-status.ts
@@ -1,0 +1,132 @@
+import {
+  SaleRepository,
+  DetailedSale,
+} from '@/repositories/sale-repository'
+import { BarberUsersRepository } from '@/repositories/barber-users-repository'
+import { CashRegisterRepository } from '@/repositories/cash-register-repository'
+import { TransactionRepository } from '@/repositories/transaction-repository'
+import { OrganizationRepository } from '@/repositories/organization-repository'
+import { ProfilesRepository } from '@/repositories/profiles-repository'
+import { UnitRepository } from '@/repositories/unit-repository'
+import { PaymentStatus, TransactionType } from '@prisma/client'
+
+interface SetSaleStatusRequest {
+  saleId: string
+  userId: string
+  paymentStatus: PaymentStatus
+}
+
+interface SetSaleStatusResponse {
+  sale: DetailedSale
+}
+
+export class SetSaleStatusService {
+  constructor(
+    private saleRepository: SaleRepository,
+    private barberUserRepository: BarberUsersRepository,
+    private cashRegisterRepository: CashRegisterRepository,
+    private transactionRepository: TransactionRepository,
+    private organizationRepository: OrganizationRepository,
+    private profileRepository: ProfilesRepository,
+    private unitRepository: UnitRepository,
+  ) {}
+
+  async execute({
+    saleId,
+    userId,
+    paymentStatus,
+  }: SetSaleStatusRequest): Promise<SetSaleStatusResponse> {
+    const sale = await this.saleRepository.findById(saleId)
+    if (!sale) throw new Error('Sale not found')
+
+    if (sale.paymentStatus === paymentStatus) {
+      return { sale }
+    }
+
+    if (paymentStatus === PaymentStatus.PAID) {
+      const user = await this.barberUserRepository.findById(userId)
+      const session = await this.cashRegisterRepository.findOpenByUnit(
+        user?.unitId as string,
+      )
+      if (!session) throw new Error('Cash register closed')
+
+      const transaction = await this.transactionRepository.create({
+        user: { connect: { id: userId } },
+        unit: { connect: { id: user?.unitId } },
+        session: { connect: { id: session.id } },
+        type: TransactionType.ADDITION,
+        description: 'Sale',
+        amount: sale.total,
+      })
+
+      try {
+        const updatedSale = await this.saleRepository.update(saleId, {
+          paymentStatus,
+          session: { connect: { id: session.id } },
+          transaction: { connect: { id: transaction.id } },
+        })
+
+        const org = await this.organizationRepository.findById(
+          user?.organizationId as string,
+        )
+        if (!org) throw new Error('Org not found')
+        const barberTotals: Record<string, number> = {}
+        let ownerShare = 0
+        for (const item of updatedSale.items) {
+          const value = item.price ?? 0
+          if (item.product) {
+            ownerShare += value
+          } else if (item.barberId) {
+            const perc = item.porcentagemBarbeiro ?? 100
+            const valueBarber = (value * perc) / 100
+            barberTotals[item.barberId] =
+              (barberTotals[item.barberId] || 0) + valueBarber
+            ownerShare += value - valueBarber
+          } else {
+            ownerShare += value
+          }
+        }
+        for (const [barberId, amount] of Object.entries(barberTotals)) {
+          const userBarber = updatedSale.items.find(
+            (item) => item.barber?.id === barberId,
+          )
+          if (!userBarber) throw new Error('Barber not found')
+          if (
+            userBarber &&
+            userBarber.barber &&
+            userBarber.barber.profile &&
+            userBarber.barber.profile.totalBalance < 0
+          ) {
+            const balanceBarber = userBarber.barber.profile.totalBalance
+            const valueCalculated = balanceBarber + amount
+            if (valueCalculated <= 0) {
+              await this.unitRepository.incrementBalance(updatedSale.unitId, amount)
+            } else {
+              await this.unitRepository.incrementBalance(
+                updatedSale.unitId,
+                balanceBarber * -1,
+              )
+              await this.organizationRepository.incrementBalance(
+                org.id,
+                balanceBarber * -1,
+              )
+            }
+          }
+          await this.profileRepository.incrementBalance(barberId, amount)
+        }
+        await this.unitRepository.incrementBalance(updatedSale.unitId, ownerShare)
+        await this.organizationRepository.incrementBalance(org.id, ownerShare)
+
+        return { sale: updatedSale }
+      } catch (error) {
+        await this.transactionRepository.delete(transaction.id)
+        throw error
+      }
+    }
+
+    const updatedSale = await this.saleRepository.update(saleId, {
+      paymentStatus,
+    })
+    return { sale: updatedSale }
+  }
+}


### PR DESCRIPTION
## Summary
- support paid/pending status for sales
- allow creating sale with paymentStatus
- seed sample sale with PaymentStatus.PAID
- add PaymentStatus enum to Prisma and migration
- include paymentStatus in Insomnia requests
- add route to update sale payment status

## Testing
- `npx vitest run` *(fails: Need to install vitest)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684f463fe4548329b997d5c64684b8ee