### PR TITLE
Add controller unit tests

### DIFF
--- a/test/controllers/cash-register/close-session-controller.spec.ts
+++ b/test/controllers/cash-register/close-session-controller.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CloseSessionController } from '../../../src/http/controllers/cash-register/close-session-controller'
+import * as factory from '../../../src/services/@factories/cash-register/make-close-session'
+
+describe('CloseSessionController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeCloseSessionService').mockReturnValue(service as any)
+    execute.mockResolvedValue({ session: { id: '1' } })
+    vi.clearAllMocks()
+  })
+
+  it('should close current session and return it', async () => {
+    const request = { user: { unitId: 'unit-1' } } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await CloseSessionController(request, reply)
+
+    expect(factory.makeCloseSessionService).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith({ unitId: 'unit-1' })
+    expect(reply.status).toHaveBeenCalledWith(200)
+    expect(reply.send).toHaveBeenCalledWith({ id: '1' })
+  })
+})

--- a/test/controllers/cash-register/list-sessions-controller.spec.ts
+++ b/test/controllers/cash-register/list-sessions-controller.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ListSessionsController } from '../../../src/http/controllers/cash-register/list-sessions-controller'
+import * as factory from '../../../src/services/@factories/cash-register/make-list-sessions'
+
+describe('ListSessionsController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeListSessionsService').mockReturnValue(service as any)
+    execute.mockResolvedValue({ sessions: [{ id: '1' }] })
+    vi.clearAllMocks()
+  })
+
+  it('should list sessions for user', async () => {
+    const user = { sub: '1', unitId: 'unit-1', role: 'ADMIN', organizationId: 'org' }
+    const request = { user } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await ListSessionsController(request, reply)
+
+    expect(factory.makeListSessionsService).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith(user)
+    expect(reply.status).toHaveBeenCalledWith(200)
+    expect(reply.send).toHaveBeenCalledWith([{ id: '1' }])
+  })
+})

--- a/test/controllers/cash-register/open-session-controller.spec.ts
+++ b/test/controllers/cash-register/open-session-controller.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { OpenSessionController } from '../../../src/http/controllers/cash-register/open-session-controller'
+import * as factory from '../../../src/services/@factories/cash-register/make-open-session'
+
+describe('OpenSessionController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeOpenSessionService').mockReturnValue(service as any)
+    execute.mockResolvedValue({ session: { id: '1' } })
+    vi.clearAllMocks()
+  })
+
+  it('should open a new session', async () => {
+    const user = { sub: '1', unitId: 'unit-1', role: 'ADMIN', organizationId: 'org' }
+    const request = { user, body: { initialAmount: 100 } } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await OpenSessionController(request, reply)
+
+    expect(factory.makeOpenSessionService).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith({ initialAmount: 100, user })
+    expect(reply.status).toHaveBeenCalledWith(201)
+    expect(reply.send).toHaveBeenCalledWith({ id: '1' })
+  })
+})

--- a/test/controllers/sale/create-sale-controller.spec.ts
+++ b/test/controllers/sale/create-sale-controller.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CreateSaleController } from '../../../src/http/controllers/sale/create-sale-controller'
+import * as factory from '../../../src/services/@factories/sale/make-create-sale'
+
+describe('CreateSaleController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeCreateSale').mockReturnValue(service as any)
+    execute.mockResolvedValue({ sale: { id: '1' } })
+    vi.clearAllMocks()
+  })
+
+  it('should create a sale', async () => {
+    const request = {
+      body: {
+        method: 'CASH',
+        items: [{ serviceId: 's1', quantity: 1 }],
+        clientId: 'client1',
+      },
+      user: { sub: 'user1' },
+    } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await CreateSaleController(request, reply)
+
+    expect(factory.makeCreateSale).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith({
+      method: 'CASH',
+      items: [{ serviceId: 's1', quantity: 1 }],
+      clientId: 'client1',
+      userId: 'user1',
+      paymentStatus: 'PENDING',
+    })
+    expect(reply.status).toHaveBeenCalledWith(201)
+    expect(reply.send).toHaveBeenCalledWith({ id: '1' })
+  })
+})

--- a/test/controllers/sale/get-sale-controller.spec.ts
+++ b/test/controllers/sale/get-sale-controller.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GetSaleController } from '../../../src/http/controllers/sale/get-sale-controller'
+import * as factory from '../../../src/services/@factories/sale/make-get-sale'
+
+describe('GetSaleController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeGetSale').mockReturnValue(service as any)
+    vi.clearAllMocks()
+  })
+
+  it('should return sale if found', async () => {
+    execute.mockResolvedValue({ sale: { id: '1' } })
+    const request = { params: { id: '1' } } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await GetSaleController(request, reply)
+
+    expect(factory.makeGetSale).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith({ id: '1' })
+    expect(reply.status).toHaveBeenCalledWith(200)
+    expect(reply.send).toHaveBeenCalledWith({ id: '1' })
+  })
+
+  it('should return 404 when not found', async () => {
+    execute.mockResolvedValue({ sale: null })
+    const request = { params: { id: '2' } } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await GetSaleController(request, reply)
+
+    expect(reply.status).toHaveBeenCalledWith(404)
+    expect(reply.send).toHaveBeenCalledWith({ message: 'Sale not found' })
+  })
+})

--- a/test/controllers/sale/list-sales-controller.spec.ts
+++ b/test/controllers/sale/list-sales-controller.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ListSalesController } from '../../../src/http/controllers/sale/list-sales-controller'
+import * as factory from '../../../src/services/@factories/sale/make-list-sales'
+
+describe('ListSalesController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeListSales').mockReturnValue(service as any)
+    execute.mockResolvedValue({ sales: [{ id: '1' }] })
+    vi.clearAllMocks()
+  })
+
+  it('should list sales for user', async () => {
+    const user = { sub: '1', unitId: 'unit-1', role: 'ADMIN', organizationId: 'org' }
+    const request = { user } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await ListSalesController(request, reply)
+
+    expect(factory.makeListSales).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith(user)
+    expect(reply.status).toHaveBeenCalledWith(200)
+    expect(reply.send).toHaveBeenCalledWith([{ id: '1' }])
+  })
+})

--- a/test/controllers/sale/set-sale-status-controller.spec.ts
+++ b/test/controllers/sale/set-sale-status-controller.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SetSaleStatusController } from '../../../src/http/controllers/sale/set-sale-status-controller'
+import * as factory from '../../../src/services/@factories/sale/make-set-sale-status'
+
+describe('SetSaleStatusController', () => {
+  const execute = vi.fn()
+  const service = { execute }
+
+  beforeEach(() => {
+    vi.spyOn(factory, 'makeSetSaleStatus').mockReturnValue(service as any)
+    execute.mockResolvedValue({ sale: { id: '1' } })
+    vi.clearAllMocks()
+  })
+
+  it('should update sale status', async () => {
+    const request = {
+      params: { id: '1' },
+      body: { paymentStatus: 'PAID' },
+      user: { sub: 'user1' },
+    } as any
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as any
+
+    await SetSaleStatusController(request, reply)
+
+    expect(factory.makeSetSaleStatus).toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith({
+      saleId: '1',
+      userId: 'user1',
+      paymentStatus: 'PAID',
+    })
+    expect(reply.status).toHaveBeenCalledWith(200)
+    expect(reply.send).toHaveBeenCalledWith({ id: '1' })
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for cash register controllers
- add unit tests for sale controllers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f6ebe0aa08329acf41bb665bba556