### PR TITLE
Add create sale service tests

### DIFF
--- a/test/create-sale.spec.ts
+++ b/test/create-sale.spec.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { PaymentMethod, DiscountType, PaymentStatus } from '@prisma/client'
+import { CreateSaleService } from '../src/services/sale/create-sale'
+import {
+  FakeServiceRepository,
+  FakeProductRepository,
+  FakeCouponRepository,
+  FakeSaleRepository,
+  FakeBarberUsersRepository,
+  FakeCashRegisterRepository,
+  FakeTransactionRepository,
+  FakeOrganizationRepository,
+  FakeProfilesRepository,
+  FakeUnitRepository,
+} from './helpers/fake-repositories'
+
+import { randomUUID } from 'crypto'
+import {
+  defaultUser,
+  defaultClient,
+  barberProfile,
+  barberUser,
+} from './helpers/default-values'
+
+function setup() {
+  const serviceRepo = new FakeServiceRepository()
+  const productRepo = new FakeProductRepository()
+  const couponRepo = new FakeCouponRepository()
+  const saleRepo = new FakeSaleRepository()
+  const barberRepo = new FakeBarberUsersRepository()
+  const cashRepo = new FakeCashRegisterRepository()
+  const transactionRepo = new FakeTransactionRepository()
+  const organization = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+  const organizationRepo = new FakeOrganizationRepository(organization)
+  const profilesRepo = new FakeProfilesRepository()
+  const unit = { id: 'unit-1', name: 'Unit', slug: 'unit', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
+  const unitRepo = new FakeUnitRepository(unit)
+
+  const createSale = new CreateSaleService(
+    saleRepo,
+    serviceRepo,
+    productRepo,
+    couponRepo,
+    barberRepo,
+    cashRepo,
+    transactionRepo,
+    organizationRepo,
+    profilesRepo,
+    unitRepo,
+  )
+
+  return {
+    serviceRepo,
+    productRepo,
+    couponRepo,
+    saleRepo,
+    barberRepo,
+    cashRepo,
+    transactionRepo,
+    organizationRepo,
+    profilesRepo,
+    unitRepo,
+    createSale,
+  }
+}
+
+
+describe('Create sale service', () => {
+  let ctx: ReturnType<typeof setup>
+  beforeEach(() => {
+    ctx = setup()
+    ctx.barberRepo.users.push(defaultUser, defaultClient, barberUser)
+  })
+
+  it('creates a sale with one service item without coupon', async () => {
+    const service = { id: 'service-1', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    ctx.serviceRepo.services.push(service)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ serviceId: service.id, quantity: 1 }],
+      clientId: defaultClient.id,
+      paymentStatus: PaymentStatus.PENDING,
+    })
+
+    expect(result.sale.total).toBe(100)
+    expect(result.sale.items).toHaveLength(1)
+    expect(result.sale.items[0].price).toBe(100)
+    expect(result.sale.items[0].discount).toBe(0)
+    expect(result.sale.items[0].discountType).toBeNull()
+  })
+
+  it('creates a sale with one service item with value coupon on item', async () => {
+    const service = { id: 'service-1', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const coupon = { id: 'c1', code: 'VAL10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ serviceId: service.id, quantity: 1, couponCode: coupon.code }],
+      clientId: defaultClient.id,
+      paymentStatus: PaymentStatus.PENDING,
+    })
+
+    expect(result.sale.total).toBe(90)
+    expect(result.sale.items[0].price).toBe(90)
+    expect(result.sale.items[0].discount).toBe(10)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.VALUE)
+    expect(ctx.couponRepo.coupons[0].quantity).toBe(4)
+  })
+
+  it('creates a sale with one service item with percentage coupon on item', async () => {
+    const service = { id: 'service-2', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const coupon = { id: 'c2', code: 'PERC10', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ serviceId: service.id, quantity: 1, couponCode: coupon.code }],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(90)
+    expect(result.sale.items[0].discount).toBe(10)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.PERCENTAGE)
+  })
+
+  it('creates a sale with one service item and general value coupon', async () => {
+    const service = { id: 'service-3', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const coupon = { id: 'c3', code: 'VAL20', description: null, discount: 20, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ serviceId: service.id, quantity: 1 }],
+      clientId: defaultClient.id,
+      couponCode: coupon.code,
+    })
+
+    expect(result.sale.total).toBe(80)
+    expect(result.sale.items[0].price).toBe(80)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.VALUE)
+  })
+
+  it('creates a sale with one service item and general percentage coupon', async () => {
+    const service = { id: 'service-4', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const coupon = { id: 'c4', code: 'P20', description: null, discount: 20, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ serviceId: service.id, quantity: 1 }],
+      clientId: defaultClient.id,
+      couponCode: coupon.code,
+    })
+
+    expect(result.sale.total).toBe(80)
+    expect(result.sale.items[0].discount).toBe(20)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.PERCENTAGE)
+  })
+
+  it('creates a sale with one product item without coupon', async () => {
+    const product = { id: 'product-1', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    ctx.productRepo.products.push(product)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ productId: product.id, quantity: 2 }],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(100)
+    expect(product.quantity).toBe(3)
+  })
+
+  it('creates a sale with one product item with value coupon on item', async () => {
+    const product = { id: 'product-2', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'pc1', code: 'PV10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ productId: product.id, quantity: 2, couponCode: coupon.code }],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(90)
+    expect(result.sale.items[0].discount).toBe(10)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.VALUE)
+    expect(product.quantity).toBe(3)
+  })
+
+  it('creates a sale with one product item with percentage coupon on item', async () => {
+    const product = { id: 'product-3', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'pc2', code: 'PP10', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ productId: product.id, quantity: 2, couponCode: coupon.code }],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(90)
+    expect(result.sale.items[0].discount).toBe(10)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.PERCENTAGE)
+    expect(product.quantity).toBe(3)
+  })
+
+  it('creates a sale with one product item and general value coupon', async () => {
+    const product = { id: 'product-4', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'pc3', code: 'GV30', description: null, discount: 30, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ productId: product.id, quantity: 1 }],
+      clientId: defaultClient.id,
+      couponCode: coupon.code,
+    })
+
+    expect(result.sale.total).toBe(20)
+    expect(result.sale.items[0].price).toBe(20)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.VALUE)
+    expect(product.quantity).toBe(4)
+  })
+
+  it('creates a sale with one product item and general percentage coupon', async () => {
+    const product = { id: 'product-5', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'pc4', code: 'GP50', description: null, discount: 50, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [{ productId: product.id, quantity: 1 }],
+      clientId: defaultClient.id,
+      couponCode: coupon.code,
+    })
+
+    expect(result.sale.total).toBe(25)
+    expect(result.sale.items[0].discount).toBe(50)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.PERCENTAGE)
+    expect(product.quantity).toBe(4)
+  })
+
+  it('creates a sale with product and service items without coupons', async () => {
+    const service = { id: 'service-5', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product = { id: 'product-6', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1 },
+        { productId: product.id, quantity: 1 },
+      ],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(150)
+    expect(product.quantity).toBe(4)
+    expect(result.sale.items).toHaveLength(2)
+  })
+
+  it('creates a sale with product and service items with coupons on each item (value)', async () => {
+    const service = { id: 'service-6', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product = { id: 'product-7', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const couponService = { id: 'cs5', code: 'SV5', description: null, discount: 5, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const couponProduct = { id: 'cp5', code: 'PV5', description: null, discount: 5, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(couponService, couponProduct)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1, couponCode: couponService.code },
+        { productId: product.id, quantity: 1, couponCode: couponProduct.code },
+      ],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(140)
+    expect(result.sale.items[0].price).toBe(95)
+    expect(result.sale.items[1].price).toBe(45)
+    expect(product.quantity).toBe(4)
+  })
+
+  it('creates a sale with product and service items with coupons on each item (percentage)', async () => {
+    const service = { id: 'service-7', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product = { id: 'product-8', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const couponService = { id: 'cs6', code: 'SV10P', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const couponProduct = { id: 'cp6', code: 'PV10P', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(couponService, couponProduct)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1, couponCode: couponService.code },
+        { productId: product.id, quantity: 1, couponCode: couponProduct.code },
+      ],
+      clientId: defaultClient.id,
+    })
+
+    expect(result.sale.total).toBe(135)
+    expect(result.sale.items[0].discount).toBe(10)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.PERCENTAGE)
+    expect(result.sale.items[1].discount).toBe(10)
+    expect(result.sale.items[1].discountType).toBe(DiscountType.PERCENTAGE)
+    expect(product.quantity).toBe(4)
+  })
+
+  it('creates a sale with product and service items using general value coupon', async () => {
+    const service = { id: 'service-8', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product = { id: 'product-9', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'cg1', code: 'GVAL30', description: null, discount: 30, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1 },
+        { productId: product.id, quantity: 1 },
+      ],
+      clientId: defaultClient.id,
+      couponCode: coupon.code,
+    })
+
+    expect(result.sale.total).toBe(120)
+    expect(product.quantity).toBe(4)
+  })
+
+  it('creates a sale with product and service items using general percentage coupon', async () => {
+    const service = { id: 'service-9', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product = { id: 'product-10', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'cg2', code: 'GPERC50', description: null, discount: 50, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1 },
+        { productId: product.id, quantity: 1 },
+      ],
+      clientId: defaultClient.id,
+      couponCode: coupon.code,
+    })
+
+    expect(result.sale.total).toBe(75)
+    expect(result.sale.items[0].discount).toBe(50)
+    expect(result.sale.items[1].discount).toBe(50)
+    expect(result.sale.items[0].discountType).toBe(DiscountType.PERCENTAGE)
+    expect(product.quantity).toBe(4)
+  })
+
+  it('creates a sale with mixed coupons', async () => {
+    const service = { id: 'service-10', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product1 = { id: 'product-11', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const product2 = { id: 'product-12', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 30, unitId: 'unit-1' }
+    const couponItem = { id: 'ci1', code: 'SVC5', description: null, discount: 5, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const couponGeneral = { id: 'cg3', code: 'G10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product1, product2)
+    ctx.couponRepo.coupons.push(couponItem, couponGeneral)
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1, couponCode: couponItem.code },
+        { productId: product1.id, quantity: 1 },
+        { productId: product2.id, quantity: 1 },
+      ],
+      clientId: defaultClient.id,
+      couponCode: couponGeneral.code,
+    })
+
+    expect(result.sale.total).toBe(165)
+    expect(product1.quantity).toBe(4)
+    expect(product2.quantity).toBe(4)
+  })
+
+  it('updates balances on paid sale with barber and product', async () => {
+    const service = { id: 'service-11', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const product = { id: 'product-13', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const coupon = { id: 'pcpaid', code: 'PAID10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    ctx.serviceRepo.services.push(service)
+    ctx.productRepo.products.push(product)
+    ctx.couponRepo.coupons.push(coupon)
+    ctx.cashRepo.session = { id: 'session-1', openedById: defaultUser.id, unitId: 'unit-1', openedAt: new Date(), closedAt: null, initialAmount: 0, transactions: [], sales: [], finalAmount: null }
+    ctx.profilesRepo.profiles.push({ ...barberProfile, user: barberUser })
+
+    const result = await ctx.createSale.execute({
+      userId: defaultUser.id,
+      method: PaymentMethod.CASH,
+      items: [
+        { serviceId: service.id, quantity: 1, barberId: barberUser.id },
+        { productId: product.id, quantity: 1, couponCode: coupon.code },
+      ],
+      clientId: defaultClient.id,
+      paymentStatus: PaymentStatus.PAID,
+    })
+
+    const expectedBarber = (service.price * barberProfile.commissionPercentage) / 100
+    expect(ctx.profilesRepo.profiles[0].totalBalance).toBeCloseTo(expectedBarber)
+    const ownerShare = service.price - expectedBarber + (product.price - 10)
+    expect(ctx.unitRepo.unit.totalBalance).toBeCloseTo(ownerShare)
+    expect(ctx.organizationRepo.organization.totalBalance).toBeCloseTo(ownerShare)
+    expect(product.quantity).toBe(4)
+    expect(result.sale.total).toBe(140)
+  })
+})

--- a/test/create-sale.spec.ts
+++ b/test/create-sale.spec.ts
@@ -20,6 +20,9 @@ import {
   defaultClient,
   barberProfile,
   barberUser,
+  makeService,
+  makeProduct,
+  makeCoupon,
 } from './helpers/default-values'
 
 function setup() {
@@ -73,7 +76,7 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one service item without coupon', async () => {
-    const service = { id: 'service-1', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
+    const service = makeService('service-1', 100)
     ctx.serviceRepo.services.push(service)
 
     const result = await ctx.createSale.execute({
@@ -92,8 +95,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one service item with value coupon on item', async () => {
-    const service = { id: 'service-1', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const coupon = { id: 'c1', code: 'VAL10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-1', 100)
+    const coupon = makeCoupon('c1', 'VAL10', 10, DiscountType.VALUE)
     ctx.serviceRepo.services.push(service)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -113,8 +116,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one service item with percentage coupon on item', async () => {
-    const service = { id: 'service-2', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const coupon = { id: 'c2', code: 'PERC10', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-2', 100)
+    const coupon = makeCoupon('c2', 'PERC10', 10, DiscountType.PERCENTAGE)
     ctx.serviceRepo.services.push(service)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -131,8 +134,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one service item and general value coupon', async () => {
-    const service = { id: 'service-3', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const coupon = { id: 'c3', code: 'VAL20', description: null, discount: 20, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-3', 100)
+    const coupon = makeCoupon('c3', 'VAL20', 20, DiscountType.VALUE)
     ctx.serviceRepo.services.push(service)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -150,8 +153,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one service item and general percentage coupon', async () => {
-    const service = { id: 'service-4', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const coupon = { id: 'c4', code: 'P20', description: null, discount: 20, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-4', 100)
+    const coupon = makeCoupon('c4', 'P20', 20, DiscountType.PERCENTAGE)
     ctx.serviceRepo.services.push(service)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -169,7 +172,7 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one product item without coupon', async () => {
-    const product = { id: 'product-1', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const product = makeProduct('product-1', 50)
     ctx.productRepo.products.push(product)
 
     const result = await ctx.createSale.execute({
@@ -184,8 +187,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one product item with value coupon on item', async () => {
-    const product = { id: 'product-2', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'pc1', code: 'PV10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const product = makeProduct('product-2', 50)
+    const coupon = makeCoupon('pc1', 'PV10', 10, DiscountType.VALUE)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -203,8 +206,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one product item with percentage coupon on item', async () => {
-    const product = { id: 'product-3', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'pc2', code: 'PP10', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const product = makeProduct('product-3', 50)
+    const coupon = makeCoupon('pc2', 'PP10', 10, DiscountType.PERCENTAGE)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -222,8 +225,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one product item and general value coupon', async () => {
-    const product = { id: 'product-4', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'pc3', code: 'GV30', description: null, discount: 30, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const product = makeProduct('product-4', 50)
+    const coupon = makeCoupon('pc3', 'GV30', 30, DiscountType.VALUE)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -242,8 +245,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with one product item and general percentage coupon', async () => {
-    const product = { id: 'product-5', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'pc4', code: 'GP50', description: null, discount: 50, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const product = makeProduct('product-5', 50)
+    const coupon = makeCoupon('pc4', 'GP50', 50, DiscountType.PERCENTAGE)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)
 
@@ -262,8 +265,8 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with product and service items without coupons', async () => {
-    const service = { id: 'service-5', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product = { id: 'product-6', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
+    const service = makeService('service-5', 100)
+    const product = makeProduct('product-6', 50)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product)
 
@@ -283,10 +286,10 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with product and service items with coupons on each item (value)', async () => {
-    const service = { id: 'service-6', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product = { id: 'product-7', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const couponService = { id: 'cs5', code: 'SV5', description: null, discount: 5, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
-    const couponProduct = { id: 'cp5', code: 'PV5', description: null, discount: 5, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-6', 100)
+    const product = makeProduct('product-7', 50)
+    const couponService = makeCoupon('cs5', 'SV5', 5, DiscountType.VALUE)
+    const couponProduct = makeCoupon('cp5', 'PV5', 5, DiscountType.VALUE)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(couponService, couponProduct)
@@ -308,10 +311,10 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with product and service items with coupons on each item (percentage)', async () => {
-    const service = { id: 'service-7', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product = { id: 'product-8', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const couponService = { id: 'cs6', code: 'SV10P', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
-    const couponProduct = { id: 'cp6', code: 'PV10P', description: null, discount: 10, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-7', 100)
+    const product = makeProduct('product-8', 50)
+    const couponService = makeCoupon('cs6', 'SV10P', 10, DiscountType.PERCENTAGE)
+    const couponProduct = makeCoupon('cp6', 'PV10P', 10, DiscountType.PERCENTAGE)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(couponService, couponProduct)
@@ -335,9 +338,9 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with product and service items using general value coupon', async () => {
-    const service = { id: 'service-8', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product = { id: 'product-9', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'cg1', code: 'GVAL30', description: null, discount: 30, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-8', 100)
+    const product = makeProduct('product-9', 50)
+    const coupon = makeCoupon('cg1', 'GVAL30', 30, DiscountType.VALUE)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)
@@ -358,9 +361,9 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with product and service items using general percentage coupon', async () => {
-    const service = { id: 'service-9', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product = { id: 'product-10', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'cg2', code: 'GPERC50', description: null, discount: 50, discountType: DiscountType.PERCENTAGE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-9', 100)
+    const product = makeProduct('product-10', 50)
+    const coupon = makeCoupon('cg2', 'GPERC50', 50, DiscountType.PERCENTAGE)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)
@@ -384,11 +387,11 @@ describe('Create sale service', () => {
   })
 
   it('creates a sale with mixed coupons', async () => {
-    const service = { id: 'service-10', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product1 = { id: 'product-11', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const product2 = { id: 'product-12', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 30, unitId: 'unit-1' }
-    const couponItem = { id: 'ci1', code: 'SVC5', description: null, discount: 5, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
-    const couponGeneral = { id: 'cg3', code: 'G10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-10', 100)
+    const product1 = makeProduct('product-11', 50)
+    const product2 = makeProduct('product-12', 30)
+    const couponItem = makeCoupon('ci1', 'SVC5', 5, DiscountType.VALUE)
+    const couponGeneral = makeCoupon('cg3', 'G10', 10, DiscountType.VALUE)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product1, product2)
     ctx.couponRepo.coupons.push(couponItem, couponGeneral)
@@ -411,9 +414,9 @@ describe('Create sale service', () => {
   })
 
   it('updates balances on paid sale with barber and product', async () => {
-    const service = { id: 'service-11', name: '', description: null, imageUrl: null, cost: 0, price: 100, unitId: 'unit-1' }
-    const product = { id: 'product-13', name: '', description: null, imageUrl: null, quantity: 5, cost: 0, price: 50, unitId: 'unit-1' }
-    const coupon = { id: 'pcpaid', code: 'PAID10', description: null, discount: 10, discountType: DiscountType.VALUE, imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() }
+    const service = makeService('service-11', 100)
+    const product = makeProduct('product-13', 50)
+    const coupon = makeCoupon('pcpaid', 'PAID10', 10, DiscountType.VALUE)
     ctx.serviceRepo.services.push(service)
     ctx.productRepo.products.push(product)
     ctx.couponRepo.coupons.push(coupon)

--- a/test/helpers/default-values.ts
+++ b/test/helpers/default-values.ts
@@ -1,0 +1,49 @@
+export const defaultUser = {
+  id: 'user-1',
+  name: '',
+  email: '',
+  password: '',
+  active: true,
+  organizationId: 'org-1',
+  unitId: 'unit-1',
+  createdAt: new Date(),
+  profile: null,
+}
+
+export const defaultClient = {
+  id: 'client-1',
+  name: '',
+  email: '',
+  password: '',
+  active: true,
+  organizationId: 'org-1',
+  unitId: 'unit-1',
+  createdAt: new Date(),
+  profile: null,
+}
+
+export const barberProfile = {
+  id: 'profile-barber',
+  phone: '',
+  cpf: '',
+  genre: '',
+  birthday: '',
+  pix: '',
+  role: 'BARBER' as any,
+  commissionPercentage: 50,
+  totalBalance: 0,
+  userId: 'barber-1',
+  createdAt: new Date(),
+}
+
+export const barberUser = {
+  id: 'barber-1',
+  name: '',
+  email: '',
+  password: '',
+  active: true,
+  organizationId: 'org-1',
+  unitId: 'unit-1',
+  createdAt: new Date(),
+  profile: barberProfile,
+}

--- a/test/helpers/default-values.ts
+++ b/test/helpers/default-values.ts
@@ -1,3 +1,5 @@
+import { DiscountType, Service, Product, Coupon } from '@prisma/client'
+
 export const defaultUser = {
   id: 'user-1',
   name: '',
@@ -46,4 +48,48 @@ export const barberUser = {
   unitId: 'unit-1',
   createdAt: new Date(),
   profile: barberProfile,
+}
+
+export function makeService(id: string, price = 100): Service {
+  return {
+    id,
+    name: '',
+    description: null,
+    imageUrl: null,
+    cost: 0,
+    price,
+    unitId: 'unit-1',
+  }
+}
+
+export function makeProduct(id: string, price = 50, quantity = 5): Product {
+  return {
+    id,
+    name: '',
+    description: null,
+    imageUrl: null,
+    quantity,
+    cost: 0,
+    price,
+    unitId: 'unit-1',
+  }
+}
+
+export function makeCoupon(
+  id: string,
+  code: string,
+  discount: number,
+  type: DiscountType,
+): Coupon {
+  return {
+    id,
+    code,
+    description: null,
+    discount,
+    discountType: type,
+    imageUrl: null,
+    quantity: 5,
+    unitId: 'unit-1',
+    createdAt: new Date(),
+  }
 }

--- a/test/helpers/fake-repositories.ts
+++ b/test/helpers/fake-repositories.ts
@@ -1,0 +1,230 @@
+import {
+  DiscountType,
+  PaymentMethod,
+  PaymentStatus,
+  Prisma,
+  Service,
+  Product,
+  Coupon,
+  User,
+  Profile,
+  Unit,
+  Organization,
+  CashRegisterSession,
+  Transaction,
+  TransactionType,
+} from '@prisma/client'
+import { ServiceRepository } from '@/repositories/service-repository'
+import { ProductRepository } from '@/repositories/product-repository'
+import { CouponRepository } from '@/repositories/coupon-repository'
+import { SaleRepository, DetailedSale, DetailedSaleItem } from '@/repositories/sale-repository'
+import { BarberUsersRepository } from '@/repositories/barber-users-repository'
+import { CashRegisterRepository, CompleteCashSession } from '@/repositories/cash-register-repository'
+import { TransactionRepository } from '@/repositories/transaction-repository'
+import { OrganizationRepository } from '@/repositories/organization-repository'
+import { ProfilesRepository } from '@/repositories/profiles-repository'
+import { UnitRepository } from '@/repositories/unit-repository'
+import { randomUUID } from 'crypto'
+
+export class FakeServiceRepository implements ServiceRepository {
+  constructor(public services: Service[] = []) {}
+  create(data: Prisma.ServiceCreateInput): Promise<Service> { throw new Error('not implemented') }
+  findManyByUnit(unitId: string): Promise<Service[]> { throw new Error('not implemented') }
+  findMany(where?: Prisma.ServiceWhereInput): Promise<Service[]> { throw new Error('not implemented') }
+  async findById(id: string): Promise<Service | null> {
+    return this.services.find(s => s.id === id) ?? null
+  }
+}
+
+export class FakeProductRepository implements ProductRepository {
+  constructor(public products: Product[] = []) {}
+  create(data: Prisma.ProductCreateInput): Promise<Product> { throw new Error('not implemented') }
+  findMany(where?: Prisma.ProductWhereInput): Promise<Product[]> { throw new Error('not implemented') }
+  async findById(id: string): Promise<Product | null> {
+    return this.products.find(p => p.id === id) ?? null
+  }
+  async update(id: string, data: Prisma.ProductUpdateInput): Promise<Product> {
+    const product = this.products.find(p => p.id === id)
+    if (!product) throw new Error('Product not found')
+    if (data.quantity && typeof data.quantity === 'object' && 'decrement' in data.quantity) {
+      product.quantity -= (data.quantity.decrement as number)
+    }
+    return product
+  }
+  delete(id: string): Promise<void> { throw new Error('not implemented') }
+}
+
+export class FakeCouponRepository implements CouponRepository {
+  constructor(public coupons: Coupon[] = []) {}
+  create(data: Prisma.CouponCreateInput): Promise<Coupon> { throw new Error('not implemented') }
+  findMany(where?: Prisma.CouponWhereInput): Promise<Coupon[]> { throw new Error('not implemented') }
+  findById(id: string): Promise<Coupon | null> { throw new Error('not implemented') }
+  async findByCode(code: string): Promise<Coupon | null> {
+    return this.coupons.find(c => c.code === code) ?? null
+  }
+  async update(id: string, data: Prisma.CouponUpdateInput): Promise<Coupon> {
+    const coupon = this.coupons.find(c => c.id === id)
+    if (!coupon) throw new Error('Coupon not found')
+    if (data.quantity && typeof data.quantity === 'object' && 'decrement' in data.quantity) {
+      coupon.quantity -= (data.quantity.decrement as number)
+    }
+    return coupon
+  }
+  delete(id: string): Promise<void> { throw new Error('not implemented') }
+}
+
+export class FakeBarberUsersRepository implements BarberUsersRepository {
+  constructor(public users: (User & { profile: Profile | null; unit?: Unit | null })[] = []) {}
+  create(data: Prisma.UserCreateInput, profile: Omit<Prisma.ProfileCreateInput, 'user'>): Promise<{ user: User; profile: Profile; }> { throw new Error('not implemented') }
+  update(id: string, userData: Prisma.UserUpdateInput, profileData: Prisma.ProfileUpdateInput): Promise<{ user: User; profile: Profile | null; }> { throw new Error('not implemented') }
+  findMany(where?: Prisma.UserWhereInput): Promise<(User & { profile: Profile | null; })[]> { throw new Error('not implemented') }
+  async findById(id: string): Promise<(User & { profile: Profile | null; unit: Unit | null; }) | null> {
+    const user = this.users.find(u => u.id === id)
+    if (!user) return null
+    return { ...user, unit: user.unit ?? null }
+  }
+  findByEmail(email: string): Promise<User | null> { throw new Error('not implemented') }
+  delete(id: string): Promise<void> { throw new Error('not implemented') }
+}
+
+export class FakeCashRegisterRepository implements CashRegisterRepository {
+  constructor(public session: (CashRegisterSession & { transactions: Transaction[] }) | null = null) {}
+  create(data: Prisma.CashRegisterSessionCreateInput): Promise<CashRegisterSession> { throw new Error('not implemented') }
+  close(id: string, data: Prisma.CashRegisterSessionUpdateInput): Promise<CashRegisterSession> { throw new Error('not implemented') }
+  findMany(where?: Prisma.CashRegisterSessionWhereInput): Promise<any[]> { throw new Error('not implemented') }
+  findManyByUnit(unitId: string): Promise<any[]> { throw new Error('not implemented') }
+  findOpenByUser(userId: string): Promise<CashRegisterSession | null> { throw new Error('not implemented') }
+  async findOpenByUnit(unitId: string): Promise<(CashRegisterSession & { transactions: Transaction[] }) | null> {
+    return this.session
+  }
+  findById(id: string): Promise<CompleteCashSession | null> { throw new Error('not implemented') }
+}
+
+export class FakeTransactionRepository implements TransactionRepository {
+  public transactions: Transaction[] = []
+  async create(data: Prisma.TransactionCreateInput): Promise<Transaction> {
+    const tr: Transaction = {
+      id: randomUUID(),
+      userId: (data.user as any).connect.id,
+      affectedUserId: (data.affectedUser as any)?.connect.id,
+      unitId: (data.unit as any).connect.id,
+      cashRegisterSessionId: (data.session as any).connect.id,
+      type: data.type as TransactionType,
+      description: data.description as string,
+      amount: data.amount as number,
+      createdAt: new Date(),
+    }
+    this.transactions.push(tr)
+    return tr
+  }
+  findManyByUser(userId: string): Promise<Transaction[]> { throw new Error('not implemented') }
+  findMany(where?: Prisma.TransactionWhereInput): Promise<Transaction[]> { throw new Error('not implemented') }
+  findManyByUnit(unitId: string): Promise<Transaction[]> { throw new Error('not implemented') }
+  findManyBySession(sessionId: string): Promise<Transaction[]> { throw new Error('not implemented') }
+  async delete(id: string): Promise<void> {
+    this.transactions = this.transactions.filter(t => t.id !== id)
+  }
+}
+
+export class FakeOrganizationRepository implements OrganizationRepository {
+  constructor(public organization: Organization) {}
+  create(data: Prisma.OrganizationCreateInput): Promise<Organization> { throw new Error('not implemented') }
+  async findById(id: string): Promise<Organization | null> {
+    return this.organization.id === id ? this.organization : null
+  }
+  findMany(): Promise<Organization[]> { throw new Error('not implemented') }
+  update(id: string, data: Prisma.OrganizationUpdateInput): Promise<Organization> { throw new Error('not implemented') }
+  delete(id: string): Promise<void> { throw new Error('not implemented') }
+  async incrementBalance(id: string, amount: number): Promise<void> {
+    if (this.organization.id === id) {
+      this.organization.totalBalance += amount
+    }
+  }
+}
+
+export class FakeProfilesRepository implements ProfilesRepository {
+  constructor(public profiles: (Profile & { user: Omit<User, 'password'> })[] = []) {}
+  async findById(id: string): Promise<(Profile & { user: Omit<User, 'password'> }) | null> {
+    return this.profiles.find(p => p.id === id) ?? null
+  }
+  create(data: Prisma.ProfileUncheckedCreateInput): Promise<Profile> { throw new Error('not implemented') }
+  async findByUserId(userId: string): Promise<(Profile & { user: Omit<User, 'password'> }) | null> {
+    return this.profiles.find(p => p.user.id === userId) ?? null
+  }
+  update(id: string, data: Prisma.ProfileUncheckedUpdateInput): Promise<Profile> { throw new Error('not implemented') }
+  findMany(where?: Prisma.ProfileWhereInput, orderBy?: Prisma.ProfileOrderByWithRelationInput): Promise<(Profile & { user: Omit<User, 'password'> })[]> { throw new Error('not implemented') }
+  async incrementBalance(userId: string, amount: number): Promise<void> {
+    const profile = this.profiles.find(p => p.user.id === userId)
+    if (profile) {
+      profile.totalBalance += amount
+    }
+  }
+}
+
+export class FakeUnitRepository implements UnitRepository {
+  constructor(public unit: Unit) {}
+  create(data: Prisma.UnitCreateInput): Promise<Unit> { throw new Error('not implemented') }
+  findById(id: string): Promise<Unit | null> { throw new Error('not implemented') }
+  findManyByOrganization(organizationId: string): Promise<Unit[]> { throw new Error('not implemented') }
+  findMany(): Promise<Unit[]> { throw new Error('not implemented') }
+  update(id: string, data: Prisma.UnitUpdateInput): Promise<Unit> { throw new Error('not implemented') }
+  delete(id: string): Promise<void> { throw new Error('not implemented') }
+  async incrementBalance(id: string, amount: number): Promise<void> {
+    if (this.unit.id === id) {
+      this.unit.totalBalance += amount
+    }
+  }
+}
+
+export class FakeSaleRepository implements SaleRepository {
+  public sales: DetailedSale[] = []
+  async create(data: Prisma.SaleCreateInput): Promise<DetailedSale> {
+    const saleId = randomUUID()
+    const itemsData = (data.items as any).create as any[]
+    const items: DetailedSaleItem[] = itemsData.map((it: any) => ({
+      id: randomUUID(),
+      saleId,
+      serviceId: it.service?.connect.id,
+      productId: it.product?.connect.id,
+      quantity: it.quantity,
+      barberId: it.barber?.connect.id,
+      couponId: it.coupon?.connect.id,
+      price: it.price as number,
+      discount: it.discount ?? null,
+      discountType: it.discountType ?? null,
+      porcentagemBarbeiro: it.porcentagemBarbeiro ?? null,
+      service: it.service ? { id: it.service.connect.id, name: '', description: null, imageUrl: null, cost: 0, price: 0, unitId: 'unit-1' } : null,
+      product: it.product ? { id: it.product.connect.id, name: '', description: null, imageUrl: null, quantity: 0, cost: 0, price: 0, unitId: 'unit-1' } : null,
+      barber: it.barber ? { id: it.barber.connect.id, name: '', email: '', password: '', active: true, organizationId: 'org-1', unitId: 'unit-1', createdAt: new Date(), profile: { id: 'profile-' + it.barber.connect.id, phone: '', cpf: '', genre: '', birthday: '', pix: '', role: 'BARBER' as any, commissionPercentage: it.porcentagemBarbeiro ?? 100, totalBalance: 0, userId: it.barber.connect.id, createdAt: new Date() } } : null,
+      coupon: it.coupon ? { id: it.coupon.connect.id, code: '', description: null, discount: 0, discountType: DiscountType.VALUE, imageUrl: null, quantity: 0, unitId: 'unit-1', createdAt: new Date() } : null,
+    }))
+    const sale: DetailedSale = {
+      id: saleId,
+      userId: (data.user as any).connect.id,
+      clientId: (data.client as any).connect.id,
+      unitId: (data.unit as any).connect.id,
+      sessionId: (data.session as any)?.connect.id,
+      couponId: (data.coupon as any)?.connect.id,
+      transactionId: (data.transaction as any)?.connect.id,
+      total: data.total as number,
+      method: data.method as PaymentMethod,
+      paymentStatus: data.paymentStatus as PaymentStatus,
+      createdAt: new Date(),
+      items,
+      user: { id: (data.user as any).connect.id, name: '', email: '', password: '', active: true, organizationId: 'org-1', unitId: 'unit-1', createdAt: new Date(), profile: null },
+      client: { id: (data.client as any).connect.id, name: '', email: '', password: '', active: true, organizationId: 'org-1', unitId: 'unit-1', createdAt: new Date(), profile: null },
+      coupon: data.coupon ? { id: (data.coupon as any).connect.id, code: '', description: null, discount: 0, discountType: DiscountType.VALUE, imageUrl: null, quantity: 0, unitId: 'unit-1', createdAt: new Date() } : null,
+      session: null,
+      transaction: data.transaction ? { id: (data.transaction as any).connect.id, userId: '', affectedUserId: null, unitId: '', cashRegisterSessionId: '', type: TransactionType.ADDITION, description: '', amount: data.total as number, createdAt: new Date() } : null,
+    }
+    this.sales.push(sale)
+    return sale
+  }
+  findMany(where?: Prisma.SaleWhereInput): Promise<DetailedSale[]> { throw new Error('not implemented') }
+  findById(id: string): Promise<DetailedSale | null> { throw new Error('not implemented') }
+  update(id: string, data: Prisma.SaleUpdateInput): Promise<DetailedSale> { throw new Error('not implemented') }
+  findManyByDateRange(start: Date, end: Date): Promise<DetailedSale[]> { throw new Error('not implemented') }
+  findManyByUser(userId: string): Promise<DetailedSale[]> { throw new Error('not implemented') }
+  findManyByBarber(barberId: string): Promise<DetailedSale[]> { throw new Error('not implemented') }
+  findManyBySession(sessionId: string): Promise<DetailedSale[]> { throw new Error('not implemented') }
+}


### PR DESCRIPTION
## Summary
- add in-memory fake repositories for testing
- write unit tests for create-sale service covering coupons, products and services
- move common default objects to helper file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f8516e52c83298875d7fc36710cd1