### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Type Check
+        run: npm run typecheck
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/server.js",
     "build": "tsup src --out-dir dist",
     "lint": "eslint src --ext .ts --fix",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, typecheck, build and test on push or PR to `main`

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: TS errors)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fa97a475083298055c27d9b806f55