### PR TITLE
Add tests for user, sale and report services

### DIFF
--- a/src/repositories/in-memory/in-memory-users-repository.ts
+++ b/src/repositories/in-memory/in-memory-users-repository.ts
@@ -71,14 +71,9 @@ export class InMemoryUserRepository implements UsersRepository {
 
   async update(
     id: string,
-      if (
-        data.unit &&
-        typeof data.unit === 'object' &&
-        'connect' in data.unit
-      ) {
-        profile: current.profile,
-      const { profile: _p, password: _pw, ...rest } = this.items[index]
-      return rest as Omit<User, 'password'>
+    data: { unit: { connect: { id: string } } },
+  ): Promise<Omit<User, 'password'>> {
+    const index = this.items.findIndex((u) => u.id === id)
     if (index >= 0) {
       const current = this.items[index]
       const updated: User = { ...current }

--- a/src/repositories/in-memory/in-memory-users-repository.ts
+++ b/src/repositories/in-memory/in-memory-users-repository.ts
@@ -71,18 +71,23 @@ export class InMemoryUserRepository implements UsersRepository {
 
   async update(
     id: string,
-    data: Prisma.UserUpdateInput,
+    data: { unit: { connect: { id: string } } },
   ): Promise<Omit<User, 'password'>> {
     const index = this.items.findIndex((u) => u.id === id)
     if (index >= 0) {
       const current = this.items[index]
       const updated: User = { ...current }
-      if (data.unit && typeof data.unit === 'object' && 'connect' in data.unit) {
-        updated.unitId = (data.unit as any).connect.id
+      if (
+        data.unit &&
+        typeof data.unit === 'object' &&
+        'connect' in data.unit
+      ) {
+        updated.unitId = data.unit.connect.id
       }
       this.items[index] = {
         ...updated,
         ...(data as unknown as Partial<User>),
+        profile: null,
       }
       const { ...rest } = this.items[index]
       return rest

--- a/src/repositories/in-memory/in-memory-users-repository.ts
+++ b/src/repositories/in-memory/in-memory-users-repository.ts
@@ -71,9 +71,14 @@ export class InMemoryUserRepository implements UsersRepository {
 
   async update(
     id: string,
-    data: { unit: { connect: { id: string } } },
-  ): Promise<Omit<User, 'password'>> {
-    const index = this.items.findIndex((u) => u.id === id)
+      if (
+        data.unit &&
+        typeof data.unit === 'object' &&
+        'connect' in data.unit
+      ) {
+        profile: current.profile,
+      const { profile: _p, password: _pw, ...rest } = this.items[index]
+      return rest as Omit<User, 'password'>
     if (index >= 0) {
       const current = this.items[index]
       const updated: User = { ...current }

--- a/src/repositories/in-memory/in-memory-users-repository.ts
+++ b/src/repositories/in-memory/in-memory-users-repository.ts
@@ -76,8 +76,12 @@ export class InMemoryUserRepository implements UsersRepository {
     const index = this.items.findIndex((u) => u.id === id)
     if (index >= 0) {
       const current = this.items[index]
+      const updated: User = { ...current }
+      if (data.unit && typeof data.unit === 'object' && 'connect' in data.unit) {
+        updated.unitId = (data.unit as any).connect.id
+      }
       this.items[index] = {
-        ...current,
+        ...updated,
         ...(data as unknown as Partial<User>),
       }
       const { ...rest } = this.items[index]

--- a/test/barber-balance.spec.ts
+++ b/test/barber-balance.spec.ts
@@ -5,7 +5,8 @@ import {
   FakeBarberUsersRepository,
 } from './helpers/fake-repositories'
 
-import { barberUser } from './helpers/default-values'
+import { barberUser, makeBalanceSale, makeTransaction } from './helpers/default-values'
+import { TransactionType } from '@prisma/client'
 
 describe('Barber balance service', () => {
   let txRepo: FakeTransactionRepository
@@ -22,54 +23,19 @@ describe('Barber balance service', () => {
       unit: { organizationId: 'org-1' },
     })
 
-    const sale = {
-      items: [
-        {
-          barberId: barberUser.id,
-          price: 100,
-          porcentagemBarbeiro: 50,
-          productId: null,
-          service: { name: 'Cut' },
-          coupon: null,
-        },
-      ],
-      coupon: null,
-    }
+    const sale = makeBalanceSale()
 
     txRepo.transactions.push(
-      {
-        id: 't1',
-        userId: 'u1',
-        unitId: 'unit-1',
-        type: 'ADDITION',
-        description: '',
-        amount: 100,
-        createdAt: new Date(),
-        sale,
-        unit: { organizationId: 'org-1' },
-      } as any,
-      {
-        id: 't2',
-        userId: barberUser.id,
-        unitId: 'unit-1',
-        type: 'ADDITION',
-        description: '',
-        amount: 30,
-        createdAt: new Date(),
-        sale: null,
-        unit: { organizationId: 'org-1' },
-      } as any,
-      {
+      makeTransaction({ id: 't1', userId: 'u1', unitId: 'unit-1', amount: 100, sale, organizationId: 'org-1' }),
+      makeTransaction({ id: 't2', userId: barberUser.id, unitId: 'unit-1', amount: 30, organizationId: 'org-1' }),
+      makeTransaction({
         id: 't3',
         userId: barberUser.id,
         unitId: 'unit-1',
-        type: 'WITHDRAWAL',
-        description: '',
+        type: TransactionType.WITHDRAWAL,
         amount: 20,
-        createdAt: new Date(),
-        sale: null,
-        unit: { organizationId: 'org-1' },
-      } as any,
+        organizationId: 'org-1',
+      }),
     )
   })
 

--- a/test/barber-balance.spec.ts
+++ b/test/barber-balance.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { BarberBalanceService } from '../src/services/report/barber-balance'
+import {
+  FakeTransactionRepository,
+  FakeBarberUsersRepository,
+} from './helpers/fake-repositories'
+
+import { barberUser } from './helpers/default-values'
+
+describe('Barber balance service', () => {
+  let txRepo: FakeTransactionRepository
+  let userRepo: FakeBarberUsersRepository
+  let service: BarberBalanceService
+
+  beforeEach(() => {
+    txRepo = new FakeTransactionRepository()
+    userRepo = new FakeBarberUsersRepository()
+    service = new BarberBalanceService(txRepo, userRepo)
+
+    userRepo.users.push({
+      ...barberUser,
+      unit: { organizationId: 'org-1' },
+    })
+
+    const sale = {
+      items: [
+        {
+          barberId: barberUser.id,
+          price: 100,
+          porcentagemBarbeiro: 50,
+          productId: null,
+          service: { name: 'Cut' },
+          coupon: null,
+        },
+      ],
+      coupon: null,
+    }
+
+    txRepo.transactions.push(
+      {
+        id: 't1',
+        userId: 'u1',
+        unitId: 'unit-1',
+        type: 'ADDITION',
+        description: '',
+        amount: 100,
+        createdAt: new Date(),
+        sale,
+        unit: { organizationId: 'org-1' },
+      } as any,
+      {
+        id: 't2',
+        userId: barberUser.id,
+        unitId: 'unit-1',
+        type: 'ADDITION',
+        description: '',
+        amount: 30,
+        createdAt: new Date(),
+        sale: null,
+        unit: { organizationId: 'org-1' },
+      } as any,
+      {
+        id: 't3',
+        userId: barberUser.id,
+        unitId: 'unit-1',
+        type: 'WITHDRAWAL',
+        description: '',
+        amount: 20,
+        createdAt: new Date(),
+        sale: null,
+        unit: { organizationId: 'org-1' },
+      } as any,
+    )
+  })
+
+  it('calculates balance and history', async () => {
+    const res = await service.execute({ barberId: barberUser.id })
+    expect(res.balance).toBeCloseTo(60)
+    expect(res.historySales).toHaveLength(3)
+  })
+})
+

--- a/test/cash-session-report.spec.ts
+++ b/test/cash-session-report.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CashSessionReportService } from '../src/services/report/cash-session-report'
+import { FakeCashRegisterRepository } from './helpers/fake-repositories'
+import { TransactionType } from '@prisma/client'
+
+describe('Cash session report service', () => {
+  let repo: FakeCashRegisterRepository
+  let service: CashSessionReportService
+
+  beforeEach(() => {
+    repo = new FakeCashRegisterRepository()
+    service = new CashSessionReportService(repo)
+  })
+
+  it('calculates totals from session', async () => {
+    repo.session = {
+      id: 's1',
+      openedById: 'u1',
+      unitId: 'unit-1',
+      openedAt: new Date(),
+      closedAt: null,
+      initialAmount: 0,
+      finalAmount: null,
+      transactions: [
+        {
+          id: 't1',
+          userId: 'u1',
+          affectedUserId: null,
+          unitId: 'unit-1',
+          cashRegisterSessionId: 's1',
+          type: TransactionType.ADDITION,
+          description: '',
+          amount: 100,
+          createdAt: new Date(),
+        },
+        {
+          id: 't2',
+          userId: 'u1',
+          affectedUserId: null,
+          unitId: 'unit-1',
+          cashRegisterSessionId: 's1',
+          type: TransactionType.WITHDRAWAL,
+          description: '',
+          amount: 40,
+          createdAt: new Date(),
+        },
+      ],
+      sales: [
+        {
+          id: 'sale1',
+          userId: 'u1',
+          clientId: 'c1',
+          unitId: 'unit-1',
+          total: 150,
+          method: 'CASH',
+          paymentStatus: 'PAID',
+          createdAt: new Date(),
+          items: [
+            {
+              id: 'i1',
+              saleId: 'sale1',
+              serviceId: 'srv1',
+              productId: null,
+              quantity: 1,
+              barberId: null,
+              couponId: null,
+              price: 0,
+              discount: null,
+              discountType: null,
+              porcentagemBarbeiro: null,
+              service: { name: 'Cut', price: 100 },
+              product: null,
+              barber: null,
+              coupon: null,
+            },
+          ],
+          user: { id: 'u1', profile: { commissionPercentage: 50 } },
+          client: {},
+          coupon: null,
+          session: null,
+          transaction: null,
+        },
+      ],
+    } as any
+
+    const res = await service.execute({ sessionId: 's1' })
+    expect(res.totalIn).toBe(100)
+    expect(res.totalOut).toBe(40)
+    expect(res.totalByService['Cut']).toBe(100)
+    expect(res.barberCommissions['u1']).toBe(50)
+    expect(res.ownerTotal).toBe(50)
+  })
+})
+

--- a/test/create-coupon.spec.ts
+++ b/test/create-coupon.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CreateCouponService } from '../src/services/coupon/create-coupon'
+import { FakeCouponRepository } from './helpers/fake-repositories'
+
+describe('Create coupon service', () => {
+  let repo: FakeCouponRepository
+  let service: CreateCouponService
+
+  beforeEach(() => {
+    repo = new FakeCouponRepository([])
+    service = new CreateCouponService(repo)
+  })
+
+  it('creates coupon', async () => {
+    const res = await service.execute({
+      code: 'CP10',
+      description: null,
+      discount: 10,
+      discountType: 'VALUE',
+      imageUrl: null,
+      quantity: 5,
+      unitId: 'unit-1',
+    })
+    expect(res.coupon.code).toBe('CP10')
+    expect(repo.coupons).toHaveLength(1)
+  })
+})

--- a/test/create-organization.spec.ts
+++ b/test/create-organization.spec.ts
@@ -1,15 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { CreateOrganizationService } from '../src/services/organization/create-organization'
 import { FakeOrganizationRepository } from './helpers/fake-repositories'
-
-const base = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+import { defaultOrganization } from './helpers/default-values'
 
 describe('Create organization service', () => {
   let repo: FakeOrganizationRepository
   let service: CreateOrganizationService
 
   beforeEach(() => {
-    repo = new FakeOrganizationRepository({ ...base }, [{ ...base }])
+    repo = new FakeOrganizationRepository({ ...defaultOrganization }, [{ ...defaultOrganization }])
     service = new CreateOrganizationService(repo)
   })
 

--- a/test/create-organization.spec.ts
+++ b/test/create-organization.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CreateOrganizationService } from '../src/services/organization/create-organization'
+import { FakeOrganizationRepository } from './helpers/fake-repositories'
+
+const base = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+
+describe('Create organization service', () => {
+  let repo: FakeOrganizationRepository
+  let service: CreateOrganizationService
+
+  beforeEach(() => {
+    repo = new FakeOrganizationRepository({ ...base }, [{ ...base }])
+    service = new CreateOrganizationService(repo)
+  })
+
+  it('creates an organization', async () => {
+    const res = await service.execute({ name: 'New Org', slug: 'new' })
+    expect(res.organization.name).toBe('New Org')
+    expect(repo.organizations).toHaveLength(2)
+  })
+})

--- a/test/create-product.spec.ts
+++ b/test/create-product.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CreateProductService } from '../src/services/product/create-product'
+import { FakeProductRepository } from './helpers/fake-repositories'
+
+describe('Create product service', () => {
+  let repo: FakeProductRepository
+  let service: CreateProductService
+
+  beforeEach(() => {
+    repo = new FakeProductRepository([])
+    service = new CreateProductService(repo)
+  })
+
+  it('creates a product', async () => {
+    const result = await service.execute({
+      name: 'Prod',
+      description: null,
+      imageUrl: null,
+      quantity: 5,
+      cost: 10,
+      price: 20,
+      unitId: 'unit-1',
+    })
+    expect(result.product.name).toBe('Prod')
+    expect(repo.products).toHaveLength(1)
+    expect(repo.products[0].unitId).toBe('unit-1')
+  })
+})

--- a/test/create-service.spec.ts
+++ b/test/create-service.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CreateServiceService } from '../src/services/service/create-service'
+import { FakeServiceRepository } from './helpers/fake-repositories'
+
+describe('Create service service', () => {
+  let repo: FakeServiceRepository
+  let service: CreateServiceService
+
+  beforeEach(() => {
+    repo = new FakeServiceRepository([])
+    service = new CreateServiceService(repo)
+  })
+
+  it('creates a service', async () => {
+    const result = await service.execute({
+      name: 'Cut',
+      description: null,
+      imageUrl: null,
+      cost: 10,
+      price: 20,
+      unitId: 'unit-1',
+    })
+    expect(result.service.name).toBe('Cut')
+    expect(repo.services).toHaveLength(1)
+    expect(repo.services[0].unitId).toBe('unit-1')
+  })
+})

--- a/test/delete-coupon.spec.ts
+++ b/test/delete-coupon.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DeleteCouponService } from '../src/services/coupon/delete-coupon'
+import { FakeCouponRepository } from './helpers/fake-repositories'
+
+const coupon = {
+  id: 'c1',
+  code: 'C1',
+  description: null,
+  discount: 10,
+  discountType: 'VALUE',
+  imageUrl: null,
+  quantity: 5,
+  unitId: 'unit-1',
+  createdAt: new Date(),
+} as any
+
+describe('Delete coupon service', () => {
+  let repo: FakeCouponRepository
+  let service: DeleteCouponService
+
+  beforeEach(() => {
+    repo = new FakeCouponRepository([coupon])
+    service = new DeleteCouponService(repo)
+  })
+
+  it('removes coupon', async () => {
+    await service.execute({ id: 'c1' })
+    expect(repo.coupons).toHaveLength(0)
+  })
+})

--- a/test/delete-coupon.spec.ts
+++ b/test/delete-coupon.spec.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { DeleteCouponService } from '../src/services/coupon/delete-coupon'
 import { FakeCouponRepository } from './helpers/fake-repositories'
+import { makeCoupon } from './helpers/default-values'
+import { DiscountType } from '@prisma/client'
 
-const coupon = {
-  id: 'c1',
-  code: 'C1',
-  description: null,
-  discount: 10,
-  discountType: 'VALUE',
-  imageUrl: null,
-  quantity: 5,
-  unitId: 'unit-1',
-  createdAt: new Date(),
-} as any
+const coupon = makeCoupon('c1', 'C1', 10, DiscountType.VALUE)
 
 describe('Delete coupon service', () => {
   let repo: FakeCouponRepository

--- a/test/delete-organization.spec.ts
+++ b/test/delete-organization.spec.ts
@@ -1,15 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { DeleteOrganizationService } from '../src/services/organization/delete-organization'
 import { FakeOrganizationRepository } from './helpers/fake-repositories'
-
-const org = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+import { defaultOrganization } from './helpers/default-values'
 
 describe('Delete organization service', () => {
   let repo: FakeOrganizationRepository
   let service: DeleteOrganizationService
 
   beforeEach(() => {
-    repo = new FakeOrganizationRepository(org, [org])
+    repo = new FakeOrganizationRepository({ ...defaultOrganization }, [{ ...defaultOrganization }])
     service = new DeleteOrganizationService(repo)
   })
 

--- a/test/delete-organization.spec.ts
+++ b/test/delete-organization.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DeleteOrganizationService } from '../src/services/organization/delete-organization'
+import { FakeOrganizationRepository } from './helpers/fake-repositories'
+
+const org = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+
+describe('Delete organization service', () => {
+  let repo: FakeOrganizationRepository
+  let service: DeleteOrganizationService
+
+  beforeEach(() => {
+    repo = new FakeOrganizationRepository(org, [org])
+    service = new DeleteOrganizationService(repo)
+  })
+
+  it('deletes organization', async () => {
+    await service.execute('org-1')
+    expect(repo.organizations).toHaveLength(0)
+  })
+})

--- a/test/delete-product.spec.ts
+++ b/test/delete-product.spec.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { DeleteProductService } from '../src/services/product/delete-product'
 import { FakeProductRepository } from './helpers/fake-repositories'
+import { makeProduct } from './helpers/default-values'
 
-const product = {
-  id: 'p1',
-  name: 'Prod',
-  description: null,
-  imageUrl: null,
-  quantity: 5,
-  cost: 10,
-  price: 20,
-  unitId: 'unit-1',
-} as any
+const product = makeProduct('p1', 20)
 
 describe('Delete product service', () => {
   let repo: FakeProductRepository

--- a/test/delete-product.spec.ts
+++ b/test/delete-product.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DeleteProductService } from '../src/services/product/delete-product'
+import { FakeProductRepository } from './helpers/fake-repositories'
+
+const product = {
+  id: 'p1',
+  name: 'Prod',
+  description: null,
+  imageUrl: null,
+  quantity: 5,
+  cost: 10,
+  price: 20,
+  unitId: 'unit-1',
+} as any
+
+describe('Delete product service', () => {
+  let repo: FakeProductRepository
+  let service: DeleteProductService
+
+  beforeEach(() => {
+    repo = new FakeProductRepository([product])
+    service = new DeleteProductService(repo)
+  })
+
+  it('removes product', async () => {
+    await service.execute({ id: 'p1' })
+    expect(repo.products).toHaveLength(0)
+  })
+})

--- a/test/export-users.spec.ts
+++ b/test/export-users.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ExportUsersService } from '../src/services/config/export-users'
+import { FakeBarberUsersRepository } from './helpers/fake-repositories'
+import { defaultUser } from './helpers/default-values'
+
+describe('Export users service', () => {
+  let repo: FakeBarberUsersRepository
+  let service: ExportUsersService
+
+  beforeEach(() => {
+    repo = new FakeBarberUsersRepository([{ ...defaultUser, profile: null, unit: null }])
+    service = new ExportUsersService(repo)
+  })
+
+  it('returns all users', async () => {
+    const res = await service.execute()
+    expect(res.users).toHaveLength(1)
+  })
+})

--- a/test/get-coupon.spec.ts
+++ b/test/get-coupon.spec.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { GetCouponService } from '../src/services/coupon/get-coupon'
 import { FakeCouponRepository } from './helpers/fake-repositories'
+import { makeCoupon } from './helpers/default-values'
+import { DiscountType } from '@prisma/client'
 
-const coupon = {
-  id: 'c1',
-  code: 'C1',
-  description: null,
-  discount: 10,
-  discountType: 'VALUE',
-  imageUrl: null,
-  quantity: 5,
-  unitId: 'unit-1',
-  createdAt: new Date(),
-} as any
+const coupon = makeCoupon('c1', 'C1', 10, DiscountType.VALUE)
 
 describe('Get coupon service', () => {
   let repo: FakeCouponRepository

--- a/test/get-coupon.spec.ts
+++ b/test/get-coupon.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GetCouponService } from '../src/services/coupon/get-coupon'
+import { FakeCouponRepository } from './helpers/fake-repositories'
+
+const coupon = {
+  id: 'c1',
+  code: 'C1',
+  description: null,
+  discount: 10,
+  discountType: 'VALUE',
+  imageUrl: null,
+  quantity: 5,
+  unitId: 'unit-1',
+  createdAt: new Date(),
+} as any
+
+describe('Get coupon service', () => {
+  let repo: FakeCouponRepository
+  let service: GetCouponService
+
+  beforeEach(() => {
+    repo = new FakeCouponRepository([coupon])
+    service = new GetCouponService(repo)
+  })
+
+  it('returns coupon when found', async () => {
+    const res = await service.execute({ id: 'c1' })
+    expect(res.coupon?.id).toBe('c1')
+  })
+
+  it('returns null when not found', async () => {
+    const res = await service.execute({ id: 'other' })
+    expect(res.coupon).toBeNull()
+  })
+})

--- a/test/get-organization.spec.ts
+++ b/test/get-organization.spec.ts
@@ -1,15 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { GetOrganizationService } from '../src/services/organization/get-organization'
 import { FakeOrganizationRepository } from './helpers/fake-repositories'
-
-const org = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+import { defaultOrganization } from './helpers/default-values'
 
 describe('Get organization service', () => {
   let repo: FakeOrganizationRepository
   let service: GetOrganizationService
 
   beforeEach(() => {
-    repo = new FakeOrganizationRepository(org, [org])
+    repo = new FakeOrganizationRepository({ ...defaultOrganization }, [{ ...defaultOrganization }])
     service = new GetOrganizationService(repo)
   })
 

--- a/test/get-organization.spec.ts
+++ b/test/get-organization.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GetOrganizationService } from '../src/services/organization/get-organization'
+import { FakeOrganizationRepository } from './helpers/fake-repositories'
+
+const org = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+
+describe('Get organization service', () => {
+  let repo: FakeOrganizationRepository
+  let service: GetOrganizationService
+
+  beforeEach(() => {
+    repo = new FakeOrganizationRepository(org, [org])
+    service = new GetOrganizationService(repo)
+  })
+
+  it('returns organization when found', async () => {
+    const res = await service.execute('org-1')
+    expect(res.organization?.id).toBe('org-1')
+  })
+
+  it('returns null when not found', async () => {
+    const res = await service.execute('other')
+    expect(res.organization).toBeNull()
+  })
+})

--- a/test/get-product.spec.ts
+++ b/test/get-product.spec.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { GetProductService } from '../src/services/product/get-product'
 import { FakeProductRepository } from './helpers/fake-repositories'
+import { makeProduct } from './helpers/default-values'
 
-const product = {
-  id: 'p1',
-  name: 'Prod',
-  description: null,
-  imageUrl: null,
-  quantity: 5,
-  cost: 10,
-  price: 20,
-  unitId: 'unit-1',
-} as any
+const product = makeProduct('p1', 20)
 
 describe('Get product service', () => {
   let repo: FakeProductRepository

--- a/test/get-product.spec.ts
+++ b/test/get-product.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GetProductService } from '../src/services/product/get-product'
+import { FakeProductRepository } from './helpers/fake-repositories'
+
+const product = {
+  id: 'p1',
+  name: 'Prod',
+  description: null,
+  imageUrl: null,
+  quantity: 5,
+  cost: 10,
+  price: 20,
+  unitId: 'unit-1',
+} as any
+
+describe('Get product service', () => {
+  let repo: FakeProductRepository
+  let service: GetProductService
+
+  beforeEach(() => {
+    repo = new FakeProductRepository([product])
+    service = new GetProductService(repo)
+  })
+
+  it('returns product when found', async () => {
+    const res = await service.execute({ id: 'p1' })
+    expect(res.product?.id).toBe('p1')
+  })
+
+  it('returns null when not found', async () => {
+    const res = await service.execute({ id: 'other' })
+    expect(res.product).toBeNull()
+  })
+})

--- a/test/get-profile-from-userId-service.spec.ts
+++ b/test/get-profile-from-userId-service.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GetUserProfileFromUserIdService } from '../src/services/profile/get-profile-from-userId-service'
+import { FakeProfilesRepository } from './helpers/fake-repositories'
+import { ResourceNotFoundError } from '../src/services/@errors/resource-not-found-error'
+
+describe('Get profile from user id service', () => {
+  let repo: FakeProfilesRepository
+  let service: GetUserProfileFromUserIdService
+
+  beforeEach(() => {
+    repo = new FakeProfilesRepository()
+    service = new GetUserProfileFromUserIdService(repo)
+  })
+
+  it('returns profile', async () => {
+    repo.profiles.push({
+      id: 'p1',
+      phone: '',
+      cpf: '',
+      genre: '',
+      birthday: '',
+      pix: '',
+      role: 'BARBER' as any,
+      commissionPercentage: 100,
+      totalBalance: 0,
+      userId: 'u1',
+      createdAt: new Date(),
+      user: {
+        id: 'u1',
+        name: '',
+        email: '',
+        password: '',
+        active: true,
+        organizationId: 'org-1',
+        unitId: 'unit-1',
+        createdAt: new Date(),
+      },
+    })
+    const res = await service.execute({ id: 'u1' })
+    expect(res.profile?.id).toBe('p1')
+  })
+
+  it('throws when not found', async () => {
+    await expect(service.execute({ id: 'no' })).rejects.toBeInstanceOf(ResourceNotFoundError)
+  })
+})
+

--- a/test/get-profile-from-userId-service.spec.ts
+++ b/test/get-profile-from-userId-service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { GetUserProfileFromUserIdService } from '../src/services/profile/get-profile-from-userId-service'
 import { FakeProfilesRepository } from './helpers/fake-repositories'
+import { makeProfile } from './helpers/default-values'
 import { ResourceNotFoundError } from '../src/services/@errors/resource-not-found-error'
 
 describe('Get profile from user id service', () => {
@@ -13,29 +14,7 @@ describe('Get profile from user id service', () => {
   })
 
   it('returns profile', async () => {
-    repo.profiles.push({
-      id: 'p1',
-      phone: '',
-      cpf: '',
-      genre: '',
-      birthday: '',
-      pix: '',
-      role: 'BARBER' as any,
-      commissionPercentage: 100,
-      totalBalance: 0,
-      userId: 'u1',
-      createdAt: new Date(),
-      user: {
-        id: 'u1',
-        name: '',
-        email: '',
-        password: '',
-        active: true,
-        organizationId: 'org-1',
-        unitId: 'unit-1',
-        createdAt: new Date(),
-      },
-    })
+    repo.profiles.push(makeProfile('p1', 'u1'))
     const res = await service.execute({ id: 'u1' })
     expect(res.profile?.id).toBe('p1')
   })

--- a/test/get-sale.spec.ts
+++ b/test/get-sale.spec.ts
@@ -1,27 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { GetSaleService } from '../src/services/sale/get-sale'
 import { FakeSaleRepository } from './helpers/fake-repositories'
+import { makeSale } from './helpers/default-values'
 
 describe('Get sale service', () => {
   let repo: FakeSaleRepository
   let service: GetSaleService
 
-  const sale = {
-    id: 'sale-1',
-    userId: 'u1',
-    clientId: 'c1',
-    unitId: 'unit-1',
-    total: 100,
-    method: 'CASH',
-    paymentStatus: 'PENDING',
-    createdAt: new Date(),
-    items: [],
-    user: {},
-    client: {},
-    coupon: null,
-    session: null,
-    transaction: null,
-  } as any
+  const sale = makeSale('sale-1')
 
   beforeEach(() => {
     repo = new FakeSaleRepository()

--- a/test/get-sale.spec.ts
+++ b/test/get-sale.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GetSaleService } from '../src/services/sale/get-sale'
+import { FakeSaleRepository } from './helpers/fake-repositories'
+
+describe('Get sale service', () => {
+  let repo: FakeSaleRepository
+  let service: GetSaleService
+
+  const sale = {
+    id: 'sale-1',
+    userId: 'u1',
+    clientId: 'c1',
+    unitId: 'unit-1',
+    total: 100,
+    method: 'CASH',
+    paymentStatus: 'PENDING',
+    createdAt: new Date(),
+    items: [],
+    user: {},
+    client: {},
+    coupon: null,
+    session: null,
+    transaction: null,
+  } as any
+
+  beforeEach(() => {
+    repo = new FakeSaleRepository()
+    repo.sales.push(sale)
+    service = new GetSaleService(repo)
+  })
+
+  it('returns sale when found', async () => {
+    const res = await service.execute({ id: 'sale-1' })
+    expect(res.sale?.id).toBe('sale-1')
+  })
+
+  it('returns null when not found', async () => {
+    const res = await service.execute({ id: 'other' })
+    expect(res.sale).toBeNull()
+  })
+})
+

--- a/test/helpers/default-values.ts
+++ b/test/helpers/default-values.ts
@@ -7,6 +7,9 @@ import {
   Unit,
   Profile,
   User,
+  PaymentMethod,
+  PaymentStatus,
+  TransactionType,
 } from '@prisma/client'
 
 export const defaultUser = {
@@ -162,4 +165,128 @@ export function makeUser(
   unit: Unit,
 ): User & { profile: Profile; unit: Unit } {
   return { ...defaultUser, id, profile, unit }
+}
+export function makeOrganization(
+  id: string,
+  name = 'Org',
+  slug = 'org',
+): Organization {
+  return { id, name, slug, ownerId: null, totalBalance: 0, createdAt: new Date() }
+}
+
+export function makeUnit(
+  id: string,
+  name = 'Unit',
+  slug = 'unit',
+  organizationId = 'org-1',
+): Unit {
+  return { id, name, slug, organizationId, totalBalance: 0, allowsLoan: false }
+}
+
+export function makeSale(
+  id: string,
+  unitId = 'unit-1',
+  organizationId = 'org-1',
+  status: PaymentStatus = PaymentStatus.PENDING,
+  total = 100,
+): any {
+  return {
+    id,
+    userId: 'u1',
+    clientId: 'c1',
+    unitId,
+    total,
+    method: 'CASH' as PaymentMethod,
+    paymentStatus: status,
+    createdAt: new Date(),
+    items: [],
+    user: {},
+    client: {},
+    coupon: null,
+    session: null,
+    transaction: null,
+    unit: { organizationId },
+  } as any
+}
+
+export function makeSaleWithBarber(): any {
+  return {
+    id: 'sale-1',
+    userId: 'cashier',
+    clientId: 'c1',
+    unitId: defaultUnit.id,
+    total: 100,
+    method: 'CASH' as PaymentMethod,
+    paymentStatus: PaymentStatus.PENDING,
+    createdAt: new Date(),
+    items: [
+      {
+        id: 'i1',
+        saleId: 'sale-1',
+        serviceId: null,
+        productId: null,
+        quantity: 1,
+        barberId: barberUser.id,
+        couponId: null,
+        price: 100,
+        discount: null,
+        discountType: null,
+        porcentagemBarbeiro: barberProfile.commissionPercentage,
+        service: null,
+        product: null,
+        barber: { ...barberUser, profile: barberProfile },
+        coupon: null,
+      },
+    ],
+    user: { ...defaultUser },
+    client: { ...defaultUser },
+    coupon: null,
+    session: null,
+    transaction: null,
+  } as any
+}
+
+export function makeBalanceSale(barberId: string = barberUser.id): any {
+  return {
+    items: [
+      {
+        barberId,
+        price: 100,
+        porcentagemBarbeiro: 50,
+        productId: null,
+        service: { name: 'Cut' },
+        quantity: 1,
+        coupon: null,
+      },
+    ],
+    coupon: null,
+  }
+}
+
+export function makeTransaction(over: any = {}): any {
+  return {
+    id: over.id ?? 't1',
+    userId: over.userId ?? 'u1',
+    affectedUserId: null,
+    unitId: over.unitId ?? 'unit-1',
+    cashRegisterSessionId: 's1',
+    type: over.type ?? TransactionType.ADDITION,
+    description: '',
+    amount: over.amount ?? 10,
+    createdAt: new Date(),
+    unit: { organizationId: over.organizationId ?? 'org-1' },
+    sale: over.sale ?? null,
+  }
+}
+
+export const namedUser = {
+  id: 'user-1',
+  name: 'John',
+  email: 'john@example.com',
+  password: '123',
+  active: true,
+  organizationId: 'org-1',
+  unitId: 'unit-1',
+  createdAt: new Date(),
+  profile: null,
 }

--- a/test/list-coupons.spec.ts
+++ b/test/list-coupons.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListCouponsService } from '../src/services/coupon/list-coupons'
+import { FakeCouponRepository } from './helpers/fake-repositories'
+
+const c1 = { id: 'c1', code: 'C1', description: null, discount: 10, discountType: 'VALUE', imageUrl: null, quantity: 5, unitId: 'unit-1', organizationId: 'org-1', createdAt: new Date() } as any
+const c2 = { id: 'c2', code: 'C2', description: null, discount: 20, discountType: 'VALUE', imageUrl: null, quantity: 5, unitId: 'unit-2', organizationId: 'org-2', createdAt: new Date() } as any
+
+describe('List coupons service', () => {
+  let repo: FakeCouponRepository
+  let service: ListCouponsService
+
+  beforeEach(() => {
+    repo = new FakeCouponRepository([c1, c2])
+    service = new ListCouponsService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.coupons).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({ sub: '1', role: 'OWNER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.coupons).toHaveLength(1)
+    expect(res.coupons[0].id).toBe('c1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-2', organizationId: 'org-2' } as any)
+    expect(res.coupons).toHaveLength(1)
+    expect(res.coupons[0].id).toBe('c2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})

--- a/test/list-coupons.spec.ts
+++ b/test/list-coupons.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListCouponsService } from '../src/services/coupon/list-coupons'
 import { FakeCouponRepository } from './helpers/fake-repositories'
+import { makeCoupon } from './helpers/default-values'
+import { DiscountType } from '@prisma/client'
 
-const c1 = { id: 'c1', code: 'C1', description: null, discount: 10, discountType: 'VALUE', imageUrl: null, quantity: 5, unitId: 'unit-1', organizationId: 'org-1', createdAt: new Date() } as any
-const c2 = { id: 'c2', code: 'C2', description: null, discount: 20, discountType: 'VALUE', imageUrl: null, quantity: 5, unitId: 'unit-2', organizationId: 'org-2', createdAt: new Date() } as any
+const c1 = { ...makeCoupon('c1', 'C1', 10, DiscountType.VALUE), organizationId: 'org-1' } as any
+const c2 = { ...makeCoupon('c2', 'C2', 20, DiscountType.VALUE), unitId: 'unit-2', organizationId: 'org-2' } as any
 
 describe('List coupons service', () => {
   let repo: FakeCouponRepository

--- a/test/list-organizations.spec.ts
+++ b/test/list-organizations.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListOrganizationsService } from '../src/services/organization/list-organizations'
+import { FakeOrganizationRepository } from './helpers/fake-repositories'
+
+const o1 = { id: 'org-1', name: 'A', slug: 'a', ownerId: null, totalBalance: 0, createdAt: new Date() }
+const o2 = { id: 'org-2', name: 'B', slug: 'b', ownerId: null, totalBalance: 0, createdAt: new Date() }
+
+describe('List organizations service', () => {
+  let repo: FakeOrganizationRepository
+  let service: ListOrganizationsService
+
+  beforeEach(() => {
+    repo = new FakeOrganizationRepository(o1, [o1, o2])
+    service = new ListOrganizationsService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.organizations).toHaveLength(2)
+  })
+
+  it('returns organization of user for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.organizations).toHaveLength(1)
+    expect(res.organizations[0].id).toBe('org-1')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})

--- a/test/list-organizations.spec.ts
+++ b/test/list-organizations.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListOrganizationsService } from '../src/services/organization/list-organizations'
 import { FakeOrganizationRepository } from './helpers/fake-repositories'
+import { makeOrganization } from './helpers/default-values'
 
-const o1 = { id: 'org-1', name: 'A', slug: 'a', ownerId: null, totalBalance: 0, createdAt: new Date() }
-const o2 = { id: 'org-2', name: 'B', slug: 'b', ownerId: null, totalBalance: 0, createdAt: new Date() }
+const o1 = makeOrganization('org-1', 'A', 'a')
+const o2 = makeOrganization('org-2', 'B', 'b')
 
 describe('List organizations service', () => {
   let repo: FakeOrganizationRepository

--- a/test/list-products.spec.ts
+++ b/test/list-products.spec.ts
@@ -1,30 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListProductsService } from '../src/services/product/list-products'
 import { FakeProductRepository } from './helpers/fake-repositories'
+import { makeProduct } from './helpers/default-values'
 
-const p1 = {
-  id: 'p1',
-  name: 'A',
-  description: null,
-  imageUrl: null,
-  quantity: 5,
-  cost: 0,
-  price: 10,
-  unitId: 'unit-1',
-  organizationId: 'org-1',
-} as any
-
-const p2 = {
-  id: 'p2',
-  name: 'B',
-  description: null,
-  imageUrl: null,
-  quantity: 5,
-  cost: 0,
-  price: 20,
-  unitId: 'unit-2',
-  organizationId: 'org-2',
-} as any
+const p1 = { ...makeProduct('p1', 10), organizationId: 'org-1' } as any
+const p2 = { ...makeProduct('p2', 20), unitId: 'unit-2', organizationId: 'org-2' } as any
 
 describe('List products service', () => {
   let repo: FakeProductRepository

--- a/test/list-products.spec.ts
+++ b/test/list-products.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListProductsService } from '../src/services/product/list-products'
+import { FakeProductRepository } from './helpers/fake-repositories'
+
+const p1 = {
+  id: 'p1',
+  name: 'A',
+  description: null,
+  imageUrl: null,
+  quantity: 5,
+  cost: 0,
+  price: 10,
+  unitId: 'unit-1',
+  organizationId: 'org-1',
+} as any
+
+const p2 = {
+  id: 'p2',
+  name: 'B',
+  description: null,
+  imageUrl: null,
+  quantity: 5,
+  cost: 0,
+  price: 20,
+  unitId: 'unit-2',
+  organizationId: 'org-2',
+} as any
+
+describe('List products service', () => {
+  let repo: FakeProductRepository
+  let service: ListProductsService
+
+  beforeEach(() => {
+    repo = new FakeProductRepository([p1, p2])
+    service = new ListProductsService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.products).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({ sub: '1', role: 'OWNER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.products).toHaveLength(1)
+    expect(res.products[0].id).toBe('p1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-2', organizationId: 'org-2' } as any)
+    expect(res.products).toHaveLength(1)
+    expect(res.products[0].id).toBe('p2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})

--- a/test/list-sales.spec.ts
+++ b/test/list-sales.spec.ts
@@ -1,42 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListSalesService } from '../src/services/sale/list-sales'
 import { FakeSaleRepository } from './helpers/fake-repositories'
+import { makeSale } from './helpers/default-values'
 
-const s1 = {
-  id: 's1',
-  userId: 'u',
-  clientId: 'c',
-  unitId: 'unit-1',
-  total: 0,
-  method: 'CASH',
-  paymentStatus: 'PENDING',
-  createdAt: new Date(),
-  items: [],
-  user: {},
-  client: {},
-  coupon: null,
-  session: null,
-  transaction: null,
-  unit: { organizationId: 'org-1' },
-} as any
-
-const s2 = {
-  id: 's2',
-  userId: 'u',
-  clientId: 'c',
-  unitId: 'unit-2',
-  total: 0,
-  method: 'CASH',
-  paymentStatus: 'PENDING',
-  createdAt: new Date(),
-  items: [],
-  user: {},
-  client: {},
-  coupon: null,
-  session: null,
-  transaction: null,
-  unit: { organizationId: 'org-2' },
-} as any
+const s1 = makeSale('s1', 'unit-1', 'org-1')
+const s2 = makeSale('s2', 'unit-2', 'org-2')
 
 describe('List sales service', () => {
   let repo: FakeSaleRepository

--- a/test/list-sales.spec.ts
+++ b/test/list-sales.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListSalesService } from '../src/services/sale/list-sales'
+import { FakeSaleRepository } from './helpers/fake-repositories'
+
+const s1 = {
+  id: 's1',
+  userId: 'u',
+  clientId: 'c',
+  unitId: 'unit-1',
+  total: 0,
+  method: 'CASH',
+  paymentStatus: 'PENDING',
+  createdAt: new Date(),
+  items: [],
+  user: {},
+  client: {},
+  coupon: null,
+  session: null,
+  transaction: null,
+  unit: { organizationId: 'org-1' },
+} as any
+
+const s2 = {
+  id: 's2',
+  userId: 'u',
+  clientId: 'c',
+  unitId: 'unit-2',
+  total: 0,
+  method: 'CASH',
+  paymentStatus: 'PENDING',
+  createdAt: new Date(),
+  items: [],
+  user: {},
+  client: {},
+  coupon: null,
+  session: null,
+  transaction: null,
+  unit: { organizationId: 'org-2' },
+} as any
+
+describe('List sales service', () => {
+  let repo: FakeSaleRepository
+  let service: ListSalesService
+
+  beforeEach(() => {
+    repo = new FakeSaleRepository()
+    repo.sales.push(s1, s2)
+    service = new ListSalesService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({
+      sub: '1',
+      role: 'ADMIN',
+      unitId: 'unit-1',
+      organizationId: 'org-1',
+    } as any)
+    expect(res.sales).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({
+      sub: '1',
+      role: 'OWNER',
+      unitId: 'unit-1',
+      organizationId: 'org-1',
+    } as any)
+    expect(res.sales).toHaveLength(1)
+    expect(res.sales[0].id).toBe('s1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({
+      sub: '1',
+      role: 'BARBER',
+      unitId: 'unit-2',
+      organizationId: 'org-2',
+    } as any)
+    expect(res.sales).toHaveLength(1)
+    expect(res.sales[0].id).toBe('s2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({
+        sub: '',
+        role: 'ADMIN',
+        unitId: 'unit-1',
+        organizationId: 'org-1',
+      } as any),
+    ).rejects.toThrow('User not found')
+  })
+})
+

--- a/test/list-services.spec.ts
+++ b/test/list-services.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListServicesService } from '../src/services/service/list-services'
 import { FakeServiceRepository } from './helpers/fake-repositories'
+import { makeService } from './helpers/default-values'
 
-const s1 = { id: 's1', name: 'A', description: null, imageUrl: null, cost: 0, price: 10, unitId: 'unit-1', organizationId: 'org-1' } as any
-const s2 = { id: 's2', name: 'B', description: null, imageUrl: null, cost: 0, price: 20, unitId: 'unit-2', organizationId: 'org-2' } as any
+const s1 = { ...makeService('s1', 10), organizationId: 'org-1' } as any
+const s2 = { ...makeService('s2', 20), unitId: 'unit-2', organizationId: 'org-2' } as any
 
 describe('List services service', () => {
   let repo: FakeServiceRepository

--- a/test/list-services.spec.ts
+++ b/test/list-services.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListServicesService } from '../src/services/service/list-services'
+import { FakeServiceRepository } from './helpers/fake-repositories'
+
+const s1 = { id: 's1', name: 'A', description: null, imageUrl: null, cost: 0, price: 10, unitId: 'unit-1', organizationId: 'org-1' } as any
+const s2 = { id: 's2', name: 'B', description: null, imageUrl: null, cost: 0, price: 20, unitId: 'unit-2', organizationId: 'org-2' } as any
+
+describe('List services service', () => {
+  let repo: FakeServiceRepository
+  let service: ListServicesService
+
+  beforeEach(() => {
+    repo = new FakeServiceRepository([s1, s2])
+    service = new ListServicesService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.services).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({ sub: '1', role: 'OWNER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.services).toHaveLength(1)
+    expect(res.services[0].id).toBe('s1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-2', organizationId: 'org-2' } as any)
+    expect(res.services).toHaveLength(1)
+    expect(res.services[0].id).toBe('s2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})

--- a/test/list-transactions.spec.ts
+++ b/test/list-transactions.spec.ts
@@ -1,19 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListTransactionsService } from '../src/services/transaction/list-transactions'
 import { FakeTransactionRepository } from './helpers/fake-repositories'
-
-const base = (over?: any) => ({
-  id: over?.id ?? 't1',
-  userId: over?.userId ?? 'u1',
-  affectedUserId: null,
-  unitId: over?.unitId ?? 'unit-1',
-  cashRegisterSessionId: 's1',
-  type: 'ADDITION',
-  description: '',
-  amount: 10,
-  createdAt: new Date(),
-  unit: { organizationId: over?.organizationId ?? 'org-1' },
-})
+import { makeTransaction } from './helpers/default-values'
 
 describe('List transactions service', () => {
   let repo: FakeTransactionRepository
@@ -21,8 +9,8 @@ describe('List transactions service', () => {
 
   beforeEach(() => {
     repo = new FakeTransactionRepository()
-    repo.transactions.push(base({ id: 't1', unitId: 'unit-1', organizationId: 'org-1' }))
-    repo.transactions.push(base({ id: 't2', unitId: 'unit-2', organizationId: 'org-2' }))
+    repo.transactions.push(makeTransaction({ id: 't1', unitId: 'unit-1', organizationId: 'org-1' }))
+    repo.transactions.push(makeTransaction({ id: 't2', unitId: 'unit-2', organizationId: 'org-2' }))
     service = new ListTransactionsService(repo)
   })
 

--- a/test/list-transactions.spec.ts
+++ b/test/list-transactions.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListTransactionsService } from '../src/services/transaction/list-transactions'
+import { FakeTransactionRepository } from './helpers/fake-repositories'
+
+const base = (over?: any) => ({
+  id: over?.id ?? 't1',
+  userId: over?.userId ?? 'u1',
+  affectedUserId: null,
+  unitId: over?.unitId ?? 'unit-1',
+  cashRegisterSessionId: 's1',
+  type: 'ADDITION',
+  description: '',
+  amount: 10,
+  createdAt: new Date(),
+  unit: { organizationId: over?.organizationId ?? 'org-1' },
+})
+
+describe('List transactions service', () => {
+  let repo: FakeTransactionRepository
+  let service: ListTransactionsService
+
+  beforeEach(() => {
+    repo = new FakeTransactionRepository()
+    repo.transactions.push(base({ id: 't1', unitId: 'unit-1', organizationId: 'org-1' }))
+    repo.transactions.push(base({ id: 't2', unitId: 'unit-2', organizationId: 'org-2' }))
+    service = new ListTransactionsService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.transactions).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({ sub: '1', role: 'OWNER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.transactions).toHaveLength(1)
+    expect(res.transactions[0].id).toBe('t1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-2', organizationId: 'org-2' } as any)
+    expect(res.transactions).toHaveLength(1)
+    expect(res.transactions[0].id).toBe('t2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})

--- a/test/list-units.spec.ts
+++ b/test/list-units.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ListUnitsService } from '../src/services/unit/list-units'
 import { FakeUnitRepository } from './helpers/fake-repositories'
+import { makeUnit } from './helpers/default-values'
 
-const unit1 = { id: 'unit-1', name: 'A', slug: 'a', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
-const unit2 = { id: 'unit-2', name: 'B', slug: 'b', organizationId: 'org-2', totalBalance: 0, allowsLoan: false }
+const unit1 = makeUnit('unit-1', 'A', 'a', 'org-1')
+const unit2 = makeUnit('unit-2', 'B', 'b', 'org-2')
 
 describe('List units service', () => {
   let repo: FakeUnitRepository

--- a/test/list-units.spec.ts
+++ b/test/list-units.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListUnitsService } from '../src/services/unit/list-units'
+import { FakeUnitRepository } from './helpers/fake-repositories'
+
+const unit1 = { id: 'unit-1', name: 'A', slug: 'a', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
+const unit2 = { id: 'unit-2', name: 'B', slug: 'b', organizationId: 'org-2', totalBalance: 0, allowsLoan: false }
+
+describe('List units service', () => {
+  let repo: FakeUnitRepository
+  let service: ListUnitsService
+
+  beforeEach(() => {
+    repo = new FakeUnitRepository(unit1, [unit1, unit2])
+    service = new ListUnitsService(repo)
+  })
+
+  it('lists all units for admin', async () => {
+    const result = await service.execute({ sub: '1', role: 'ADMIN', organizationId: 'org-1', unitId: 'unit-1' } as any)
+    expect(result.units).toHaveLength(2)
+  })
+
+  it('lists units from organization for non admin', async () => {
+    const result = await service.execute({ sub: '1', role: 'BARBER', organizationId: 'org-1', unitId: 'unit-1' } as any)
+    expect(result.units).toHaveLength(1)
+    expect(result.units[0].id).toBe('unit-1')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', organizationId: 'org-1', unitId: 'unit-1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})

--- a/test/owner-balance.spec.ts
+++ b/test/owner-balance.spec.ts
@@ -4,6 +4,8 @@ import {
   FakeTransactionRepository,
   FakeBarberUsersRepository,
 } from './helpers/fake-repositories'
+import { makeBalanceSale, makeTransaction, namedUser } from './helpers/default-values'
+import { TransactionType } from '@prisma/client'
 
 describe('Owner balance service', () => {
   let txRepo: FakeTransactionRepository
@@ -15,69 +17,15 @@ describe('Owner balance service', () => {
     userRepo = new FakeBarberUsersRepository()
     service = new OwnerBalanceService(txRepo, userRepo)
 
-    const owner = {
-      id: 'owner1',
-      name: '',
-      email: '',
-      password: '',
-      active: true,
-      organizationId: 'org-1',
-      unitId: 'unit-1',
-      createdAt: new Date(),
-      profile: null,
-      unit: { organizationId: 'org-1' },
-    }
+    const owner = { ...namedUser, id: 'owner1', unit: { organizationId: 'org-1' } }
     userRepo.users.push(owner as any)
 
-    const sale = {
-      items: [
-        {
-          price: 100,
-          barberId: 'b1',
-          porcentagemBarbeiro: 50,
-          service: { name: 'Cut' },
-          productId: null,
-          quantity: 1,
-          coupon: null,
-        },
-      ],
-      coupon: null,
-    }
+    const sale = makeBalanceSale('b1')
 
     txRepo.transactions.push(
-      {
-        id: 't1',
-        userId: 'x',
-        unitId: 'unit-1',
-        type: 'ADDITION',
-        description: '',
-        amount: 100,
-        createdAt: new Date(),
-        sale,
-        unit: { organizationId: 'org-1' },
-      } as any,
-      {
-        id: 't2',
-        userId: 'owner1',
-        unitId: 'unit-1',
-        type: 'ADDITION',
-        description: '',
-        amount: 20,
-        createdAt: new Date(),
-        sale: null,
-        unit: { organizationId: 'org-1' },
-      } as any,
-      {
-        id: 't3',
-        userId: 'owner1',
-        unitId: 'unit-1',
-        type: 'WITHDRAWAL',
-        description: '',
-        amount: 10,
-        createdAt: new Date(),
-        sale: null,
-        unit: { organizationId: 'org-1' },
-      } as any,
+      makeTransaction({ id: 't1', userId: 'x', unitId: 'unit-1', amount: 100, sale, organizationId: 'org-1' }),
+      makeTransaction({ id: 't2', userId: 'owner1', unitId: 'unit-1', amount: 20, organizationId: 'org-1' }),
+      makeTransaction({ id: 't3', userId: 'owner1', unitId: 'unit-1', type: TransactionType.WITHDRAWAL, amount: 10, organizationId: 'org-1' }),
     )
   })
 

--- a/test/owner-balance.spec.ts
+++ b/test/owner-balance.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { OwnerBalanceService } from '../src/services/report/owner-balance'
+import {
+  FakeTransactionRepository,
+  FakeBarberUsersRepository,
+} from './helpers/fake-repositories'
+
+describe('Owner balance service', () => {
+  let txRepo: FakeTransactionRepository
+  let userRepo: FakeBarberUsersRepository
+  let service: OwnerBalanceService
+
+  beforeEach(() => {
+    txRepo = new FakeTransactionRepository()
+    userRepo = new FakeBarberUsersRepository()
+    service = new OwnerBalanceService(txRepo, userRepo)
+
+    const owner = {
+      id: 'owner1',
+      name: '',
+      email: '',
+      password: '',
+      active: true,
+      organizationId: 'org-1',
+      unitId: 'unit-1',
+      createdAt: new Date(),
+      profile: null,
+      unit: { organizationId: 'org-1' },
+    }
+    userRepo.users.push(owner as any)
+
+    const sale = {
+      items: [
+        {
+          price: 100,
+          barberId: 'b1',
+          porcentagemBarbeiro: 50,
+          service: { name: 'Cut' },
+          productId: null,
+          quantity: 1,
+          coupon: null,
+        },
+      ],
+      coupon: null,
+    }
+
+    txRepo.transactions.push(
+      {
+        id: 't1',
+        userId: 'x',
+        unitId: 'unit-1',
+        type: 'ADDITION',
+        description: '',
+        amount: 100,
+        createdAt: new Date(),
+        sale,
+        unit: { organizationId: 'org-1' },
+      } as any,
+      {
+        id: 't2',
+        userId: 'owner1',
+        unitId: 'unit-1',
+        type: 'ADDITION',
+        description: '',
+        amount: 20,
+        createdAt: new Date(),
+        sale: null,
+        unit: { organizationId: 'org-1' },
+      } as any,
+      {
+        id: 't3',
+        userId: 'owner1',
+        unitId: 'unit-1',
+        type: 'WITHDRAWAL',
+        description: '',
+        amount: 10,
+        createdAt: new Date(),
+        sale: null,
+        unit: { organizationId: 'org-1' },
+      } as any,
+    )
+  })
+
+  it('calculates owner balance', async () => {
+    const res = await service.execute({ ownerId: 'owner1' })
+    expect(res.balance).toBeCloseTo(60)
+    expect(res.historySales.length).toBe(3)
+  })
+})
+

--- a/test/register-profile-service.spec.ts
+++ b/test/register-profile-service.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CreateProfileService } from '../src/services/profile/register-profile-service'
+import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
+import { FakeProfilesRepository } from './helpers/fake-repositories'
+import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
+
+describe('Create profile service', () => {
+  let userRepo: InMemoryUserRepository
+  let profileRepo: FakeProfilesRepository
+  let service: CreateProfileService
+
+  beforeEach(() => {
+    userRepo = new InMemoryUserRepository()
+    profileRepo = new FakeProfilesRepository()
+    service = new CreateProfileService(userRepo, profileRepo)
+  })
+
+  it('throws when user not found', async () => {
+    await expect(
+      service.execute({
+        phone: '',
+        cpf: '',
+        genre: '',
+        birthday: '',
+        pix: '',
+        role: 'BARBER' as any,
+        userId: 'u1',
+      }),
+    ).rejects.toBeInstanceOf(UserNotFoundError)
+  })
+
+  it('creates profile', async () => {
+    const user = await userRepo.create({
+      name: 'John',
+      email: 'j@e.com',
+      password: '123',
+      organization: { connect: { id: 'org-1' } },
+      unit: { connect: { id: 'unit-1' } },
+    })
+
+    const res = await service.execute({
+      phone: '1',
+      cpf: '2',
+      genre: 'M',
+      birthday: '2000',
+      pix: 'x',
+      role: 'BARBER' as any,
+      userId: user.id,
+    })
+
+    expect(profileRepo.profiles).toHaveLength(1)
+    expect(res.profile.userId).toBe(user.id)
+  })
+})
+

--- a/test/request-password-reset.spec.ts
+++ b/test/request-password-reset.spec.ts
@@ -1,3 +1,6 @@
+process.env.JWT_SECRET = 'test'
+process.env.PASSWORD_SEED = 'test'
+process.env.TOKEN_EMAIL_TWILIO = 'test'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { RequestPasswordResetService } from '../src/services/users/request-password-reset'
 import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'

--- a/test/request-password-reset.spec.ts
+++ b/test/request-password-reset.spec.ts
@@ -1,13 +1,14 @@
+/* eslint-disable import/first */
 process.env.JWT_SECRET = 'test'
 process.env.PASSWORD_SEED = 'test'
 process.env.TOKEN_EMAIL_TWILIO = 'test'
+process.env.APP_WEB_URL = 'http://localhost:3000'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { RequestPasswordResetService } from '../src/services/users/request-password-reset'
 import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
 import { FakePasswordResetTokenRepository } from './helpers/fake-repositories'
 import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
 import { sendPasswordResetEmail } from '../src/lib/sendgrid'
-process.env.APP_WEB_URL = 'http://localhost:3000'
 
 vi.mock('../src/lib/sendgrid', () => ({
   sendPasswordResetEmail: vi.fn(),

--- a/test/request-password-reset.spec.ts
+++ b/test/request-password-reset.spec.ts
@@ -1,0 +1,47 @@
+process.env.APP_WEB_URL = 'http://localhost:3000'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { RequestPasswordResetService } from '../src/services/users/request-password-reset'
+import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
+import { FakePasswordResetTokenRepository } from './helpers/fake-repositories'
+import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
+import { sendPasswordResetEmail } from '../src/lib/sendgrid'
+
+vi.mock('../src/lib/sendgrid', () => ({
+  sendPasswordResetEmail: vi.fn(),
+}))
+
+describe('Request password reset service', () => {
+  let userRepo: InMemoryUserRepository
+  let tokenRepo: FakePasswordResetTokenRepository
+  let service: RequestPasswordResetService
+
+  beforeEach(() => {
+    userRepo = new InMemoryUserRepository()
+    tokenRepo = new FakePasswordResetTokenRepository()
+    service = new RequestPasswordResetService(userRepo, tokenRepo)
+    ;(sendPasswordResetEmail as any).mockClear()
+  })
+
+  it('throws when user is not found', async () => {
+    await expect(service.execute({ email: 'test@example.com' })).rejects.toBeInstanceOf(UserNotFoundError)
+  })
+
+  it('creates reset token and sends email', async () => {
+    const user = await userRepo.create({
+      name: 'John',
+      email: 'john@example.com',
+      password: '123456',
+      organization: { connect: { id: 'org-1' } },
+      unit: { connect: { id: 'unit-1' } },
+    })
+
+    await service.execute({ email: user.email })
+
+    expect(tokenRepo.tokens).toHaveLength(1)
+    expect(tokenRepo.tokens[0].userId).toBe(user.id)
+    const diff = tokenRepo.tokens[0].expiresAt.getTime() - Date.now()
+    expect(diff).toBeGreaterThan(3599000)
+    expect(diff).toBeLessThan(3601000)
+    expect(sendPasswordResetEmail).toHaveBeenCalled()
+  })
+})

--- a/test/request-password-reset.spec.ts
+++ b/test/request-password-reset.spec.ts
@@ -1,10 +1,10 @@
-process.env.APP_WEB_URL = 'http://localhost:3000'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { RequestPasswordResetService } from '../src/services/users/request-password-reset'
 import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
 import { FakePasswordResetTokenRepository } from './helpers/fake-repositories'
 import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
 import { sendPasswordResetEmail } from '../src/lib/sendgrid'
+process.env.APP_WEB_URL = 'http://localhost:3000'
 
 vi.mock('../src/lib/sendgrid', () => ({
   sendPasswordResetEmail: vi.fn(),
@@ -23,7 +23,9 @@ describe('Request password reset service', () => {
   })
 
   it('throws when user is not found', async () => {
-    await expect(service.execute({ email: 'test@example.com' })).rejects.toBeInstanceOf(UserNotFoundError)
+    await expect(
+      service.execute({ email: 'test@example.com' }),
+    ).rejects.toBeInstanceOf(UserNotFoundError)
   })
 
   it('creates reset token and sends email', async () => {

--- a/test/request-password-reset.spec.ts
+++ b/test/request-password-reset.spec.ts
@@ -1,8 +1,3 @@
-/* eslint-disable import/first */
-process.env.JWT_SECRET = 'test'
-process.env.PASSWORD_SEED = 'test'
-process.env.TOKEN_EMAIL_TWILIO = 'test'
-process.env.APP_WEB_URL = 'http://localhost:3000'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { RequestPasswordResetService } from '../src/services/users/request-password-reset'
 import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'

--- a/test/reset-password-with-token.spec.ts
+++ b/test/reset-password-with-token.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ResetPasswordWithTokenService } from '../src/services/users/reset-password-with-token'
+import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
+import { FakePasswordResetTokenRepository } from './helpers/fake-repositories'
+import { ResourceNotFoundError } from '../src/services/@errors/resource-not-found-error'
+import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
+import { compare } from 'bcryptjs'
+
+describe('Reset password with token service', () => {
+  let userRepo: InMemoryUserRepository
+  let tokenRepo: FakePasswordResetTokenRepository
+  let service: ResetPasswordWithTokenService
+  let user: any
+
+  beforeEach(async () => {
+    userRepo = new InMemoryUserRepository()
+    tokenRepo = new FakePasswordResetTokenRepository()
+    service = new ResetPasswordWithTokenService(tokenRepo, userRepo)
+    user = await userRepo.create({
+      name: 'John',
+      email: 'john@example.com',
+      password: '123456',
+      organization: { connect: { id: 'org-1' } },
+      unit: { connect: { id: 'unit-1' } },
+    })
+  })
+
+  it('throws when token not found', async () => {
+    await expect(
+      service.execute({ token: 'invalid', password: 'newpass' }),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError)
+  })
+
+  it('throws when token is expired', async () => {
+    tokenRepo.tokens.push({
+      id: '1',
+      token: 'abc',
+      userId: user.id,
+      expiresAt: new Date(Date.now() - 1000),
+    })
+
+    await expect(
+      service.execute({ token: 'abc', password: 'newpass' }),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError)
+    expect(tokenRepo.tokens).toHaveLength(0)
+  })
+
+  it('throws when user not found', async () => {
+    tokenRepo.tokens.push({
+      id: '1',
+      token: 'abc',
+      userId: 'other',
+      expiresAt: new Date(Date.now() + 1000 * 60),
+    })
+
+    await expect(
+      service.execute({ token: 'abc', password: 'newpass' }),
+    ).rejects.toBeInstanceOf(UserNotFoundError)
+  })
+
+  it('resets password and deletes token', async () => {
+    tokenRepo.tokens.push({
+      id: '1',
+      token: 'abc',
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 1000 * 60),
+    })
+
+    await service.execute({ token: 'abc', password: 'newpass' })
+
+    expect(await compare('newpass', userRepo.items[0].password)).toBe(true)
+    expect(tokenRepo.tokens).toHaveLength(0)
+  })
+})

--- a/test/sales-report.spec.ts
+++ b/test/sales-report.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SalesReportService } from '../src/services/report/sales-report'
+import { FakeSaleRepository } from './helpers/fake-repositories'
+
+describe('Sales report service', () => {
+  let repo: FakeSaleRepository
+  let service: SalesReportService
+
+  beforeEach(() => {
+    repo = new FakeSaleRepository()
+    service = new SalesReportService(repo)
+  })
+
+  it('totals sales in date range', async () => {
+    repo.sales.push(
+      {
+        id: 's1',
+        userId: 'u',
+        clientId: 'c',
+        unitId: 'unit-1',
+        total: 100,
+        method: 'CASH',
+        paymentStatus: 'PAID',
+        createdAt: new Date('2023-01-01'),
+        items: [],
+        user: {},
+        client: {},
+        coupon: null,
+        session: null,
+        transaction: null,
+      } as any,
+      {
+        id: 's2',
+        userId: 'u',
+        clientId: 'c',
+        unitId: 'unit-1',
+        total: 150,
+        method: 'CASH',
+        paymentStatus: 'PAID',
+        createdAt: new Date('2023-01-03'),
+        items: [],
+        user: {},
+        client: {},
+        coupon: null,
+        session: null,
+        transaction: null,
+      } as any,
+    )
+
+    const res = await service.execute({
+      startDate: new Date('2023-01-01'),
+      endDate: new Date('2023-01-02'),
+    })
+    expect(res.total).toBe(100)
+    expect(res.count).toBe(1)
+  })
+})
+

--- a/test/sales-report.spec.ts
+++ b/test/sales-report.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { SalesReportService } from '../src/services/report/sales-report'
 import { FakeSaleRepository } from './helpers/fake-repositories'
+import { makeSale } from './helpers/default-values'
+import { PaymentStatus } from '@prisma/client'
 
 describe('Sales report service', () => {
   let repo: FakeSaleRepository
@@ -13,38 +15,8 @@ describe('Sales report service', () => {
 
   it('totals sales in date range', async () => {
     repo.sales.push(
-      {
-        id: 's1',
-        userId: 'u',
-        clientId: 'c',
-        unitId: 'unit-1',
-        total: 100,
-        method: 'CASH',
-        paymentStatus: 'PAID',
-        createdAt: new Date('2023-01-01'),
-        items: [],
-        user: {},
-        client: {},
-        coupon: null,
-        session: null,
-        transaction: null,
-      } as any,
-      {
-        id: 's2',
-        userId: 'u',
-        clientId: 'c',
-        unitId: 'unit-1',
-        total: 150,
-        method: 'CASH',
-        paymentStatus: 'PAID',
-        createdAt: new Date('2023-01-03'),
-        items: [],
-        user: {},
-        client: {},
-        coupon: null,
-        session: null,
-        transaction: null,
-      } as any,
+      { ...makeSale('s1', 'unit-1', 'org-1', PaymentStatus.PAID, 100), createdAt: new Date('2023-01-01') } as any,
+      { ...makeSale('s2', 'unit-1', 'org-1', PaymentStatus.PAID, 150), createdAt: new Date('2023-01-03') } as any,
     )
 
     const res = await service.execute({

--- a/test/set-sale-status.spec.ts
+++ b/test/set-sale-status.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SetSaleStatusService } from '../src/services/sale/set-sale-status'
+import {
+  FakeSaleRepository,
+  FakeBarberUsersRepository,
+  FakeCashRegisterRepository,
+  FakeTransactionRepository,
+  FakeOrganizationRepository,
+  FakeProfilesRepository,
+  FakeUnitRepository,
+} from './helpers/fake-repositories'
+import {
+  barberProfile,
+  barberUser,
+  defaultUser,
+  defaultOrganization,
+  defaultUnit,
+} from './helpers/default-values'
+import { PaymentStatus } from '@prisma/client'
+
+describe('Set sale status service', () => {
+  let saleRepo: FakeSaleRepository
+  let barberRepo: FakeBarberUsersRepository
+  let cashRepo: FakeCashRegisterRepository
+  let transactionRepo: FakeTransactionRepository
+  let orgRepo: FakeOrganizationRepository
+  let profileRepo: FakeProfilesRepository
+  let unitRepo: FakeUnitRepository
+  let service: SetSaleStatusService
+
+  beforeEach(() => {
+    saleRepo = new FakeSaleRepository()
+    barberRepo = new FakeBarberUsersRepository()
+    cashRepo = new FakeCashRegisterRepository()
+    transactionRepo = new FakeTransactionRepository()
+    orgRepo = new FakeOrganizationRepository({ ...defaultOrganization })
+    profileRepo = new FakeProfilesRepository([{ ...barberProfile, user: barberUser }])
+    const unit = { ...defaultUnit }
+    unitRepo = new FakeUnitRepository(unit, [unit])
+
+    const sale = {
+      id: 'sale-1',
+      userId: 'cashier',
+      clientId: 'c1',
+      unitId: defaultUnit.id,
+      total: 100,
+      method: 'CASH',
+      paymentStatus: PaymentStatus.PENDING,
+      createdAt: new Date(),
+      items: [
+        {
+          id: 'i1',
+          saleId: 'sale-1',
+          serviceId: null,
+          productId: null,
+          quantity: 1,
+          barberId: barberUser.id,
+          couponId: null,
+          price: 100,
+          discount: null,
+          discountType: null,
+          porcentagemBarbeiro: barberProfile.commissionPercentage,
+          service: null,
+          product: null,
+          barber: { ...barberUser, profile: barberProfile },
+          coupon: null,
+        },
+      ],
+      user: { ...defaultUser },
+      client: { ...defaultUser },
+      coupon: null,
+      session: null,
+      transaction: null,
+    } as any
+
+    saleRepo.sales.push(sale)
+
+    barberRepo.users.push({
+      ...defaultUser,
+      id: 'cashier',
+      organizationId: defaultOrganization.id,
+      unitId: defaultUnit.id,
+      unit: { organizationId: defaultOrganization.id },
+    })
+
+    cashRepo.session = {
+      id: 'session-1',
+      openedById: 'cashier',
+      unitId: defaultUnit.id,
+      openedAt: new Date(),
+      closedAt: null,
+      initialAmount: 0,
+      transactions: [],
+      sales: [],
+      finalAmount: null,
+    }
+
+    service = new SetSaleStatusService(
+      saleRepo,
+      barberRepo,
+      cashRepo,
+      transactionRepo,
+      orgRepo,
+      profileRepo,
+      unitRepo,
+    )
+  })
+
+  it('returns sale when status unchanged', async () => {
+    const res = await service.execute({
+      saleId: 'sale-1',
+      userId: 'cashier',
+      paymentStatus: PaymentStatus.PENDING,
+    })
+    expect(res.sale.paymentStatus).toBe(PaymentStatus.PENDING)
+    expect(transactionRepo.transactions).toHaveLength(0)
+  })
+
+  it('marks sale as paid and updates balances', async () => {
+    const res = await service.execute({
+      saleId: 'sale-1',
+      userId: 'cashier',
+      paymentStatus: PaymentStatus.PAID,
+    })
+    expect(res.sale.paymentStatus).toBe(PaymentStatus.PAID)
+    expect(transactionRepo.transactions).toHaveLength(1)
+    expect(profileRepo.profiles[0].totalBalance).toBeCloseTo(50)
+    expect(unitRepo.unit.totalBalance).toBeCloseTo(50)
+    expect(orgRepo.organization.totalBalance).toBeCloseTo(50)
+  })
+})
+

--- a/test/set-sale-status.spec.ts
+++ b/test/set-sale-status.spec.ts
@@ -15,6 +15,7 @@ import {
   defaultUser,
   defaultOrganization,
   defaultUnit,
+  makeSaleWithBarber,
 } from './helpers/default-values'
 import { PaymentStatus } from '@prisma/client'
 
@@ -38,40 +39,7 @@ describe('Set sale status service', () => {
     const unit = { ...defaultUnit }
     unitRepo = new FakeUnitRepository(unit, [unit])
 
-    const sale = {
-      id: 'sale-1',
-      userId: 'cashier',
-      clientId: 'c1',
-      unitId: defaultUnit.id,
-      total: 100,
-      method: 'CASH',
-      paymentStatus: PaymentStatus.PENDING,
-      createdAt: new Date(),
-      items: [
-        {
-          id: 'i1',
-          saleId: 'sale-1',
-          serviceId: null,
-          productId: null,
-          quantity: 1,
-          barberId: barberUser.id,
-          couponId: null,
-          price: 100,
-          discount: null,
-          discountType: null,
-          porcentagemBarbeiro: barberProfile.commissionPercentage,
-          service: null,
-          product: null,
-          barber: { ...barberUser, profile: barberProfile },
-          coupon: null,
-        },
-      ],
-      user: { ...defaultUser },
-      client: { ...defaultUser },
-      coupon: null,
-      session: null,
-      transaction: null,
-    } as any
+    const sale = makeSaleWithBarber()
 
     saleRepo.sales.push(sale)
 

--- a/test/set-user-unit.spec.ts
+++ b/test/set-user-unit.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SetUserUnitService, UnitNotFromOrganizationError } from '../src/services/users/set-user-unit'
+import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
+import { FakeUnitRepository } from './helpers/fake-repositories'
+import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
+import { UnitNotFoundError } from '../src/services/@errors/unit-not-found-error'
+
+const user = {
+  id: 'user-1',
+  name: 'John',
+  email: 'john@example.com',
+  password: '123',
+  active: true,
+  organizationId: 'org-1',
+  unitId: 'unit-1',
+  createdAt: new Date(),
+  profile: null,
+}
+
+describe('Set user unit service', () => {
+  let userRepo: InMemoryUserRepository
+  let unitRepo: FakeUnitRepository
+  let service: SetUserUnitService
+
+  beforeEach(() => {
+    userRepo = new InMemoryUserRepository()
+    userRepo.items.push(user as any)
+    const unit = { id: 'unit-2', name: '', slug: '', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
+    unitRepo = new FakeUnitRepository(unit, [unit])
+    service = new SetUserUnitService(userRepo, unitRepo)
+  })
+
+  it('throws when user token is missing', async () => {
+    await expect(service.execute({ user: undefined as any, unitId: 'unit-2' })).rejects.toBeInstanceOf(UserNotFoundError)
+  })
+
+  it('throws when unit not found', async () => {
+    await expect(service.execute({ user: { ...user, sub: user.id } as any, unitId: 'no-unit' })).rejects.toBeInstanceOf(UnitNotFoundError)
+  })
+
+  it('throws when unit is from another organization', async () => {
+    const other = { id: 'unit-3', name: '', slug: '', organizationId: 'org-2', totalBalance: 0, allowsLoan: false }
+    unitRepo.units.push(other)
+    await expect(
+      service.execute({ user: { ...user, sub: user.id } as any, unitId: 'unit-3' }),
+    ).rejects.toBeInstanceOf(UnitNotFromOrganizationError)
+  })
+
+  it('updates user unit when valid', async () => {
+    await service.execute({ user: { ...user, sub: user.id } as any, unitId: 'unit-2' })
+    expect(userRepo.items[0].unitId).toBe('unit-2')
+  })
+})

--- a/test/set-user-unit.spec.ts
+++ b/test/set-user-unit.spec.ts
@@ -4,18 +4,9 @@ import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-
 import { FakeUnitRepository } from './helpers/fake-repositories'
 import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
 import { UnitNotFoundError } from '../src/services/@errors/unit-not-found-error'
+import { namedUser, makeUnit } from './helpers/default-values'
 
-const user = {
-  id: 'user-1',
-  name: 'John',
-  email: 'john@example.com',
-  password: '123',
-  active: true,
-  organizationId: 'org-1',
-  unitId: 'unit-1',
-  createdAt: new Date(),
-  profile: null,
-}
+const user = { ...namedUser }
 
 describe('Set user unit service', () => {
   let userRepo: InMemoryUserRepository
@@ -25,7 +16,7 @@ describe('Set user unit service', () => {
   beforeEach(() => {
     userRepo = new InMemoryUserRepository()
     userRepo.items.push(user as any)
-    const unit = { id: 'unit-2', name: '', slug: '', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
+    const unit = makeUnit('unit-2', '', '', 'org-1')
     unitRepo = new FakeUnitRepository(unit, [unit])
     service = new SetUserUnitService(userRepo, unitRepo)
   })
@@ -39,7 +30,7 @@ describe('Set user unit service', () => {
   })
 
   it('throws when unit is from another organization', async () => {
-    const other = { id: 'unit-3', name: '', slug: '', organizationId: 'org-2', totalBalance: 0, allowsLoan: false }
+    const other = makeUnit('unit-3', '', '', 'org-2')
     unitRepo.units.push(other)
     await expect(
       service.execute({ user: { ...user, sub: user.id } as any, unitId: 'unit-3' }),

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,4 @@
+process.env.JWT_SECRET ||= 'test'
+process.env.PASSWORD_SEED ||= 'test'
+process.env.TOKEN_EMAIL_TWILIO ||= 'test'
+process.env.APP_WEB_URL ||= 'http://localhost:3000'

--- a/test/update-coupon.spec.ts
+++ b/test/update-coupon.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { UpdateCouponService } from '../src/services/coupon/update-coupon'
 import { FakeCouponRepository } from './helpers/fake-repositories'
+import { makeCoupon } from './helpers/default-values'
+import { DiscountType } from '@prisma/client'
 
-const coupon = { id: 'c1', code: 'C1', description: null, discount: 10, discountType: 'VALUE', imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() } as any
+const coupon = makeCoupon('c1', 'C1', 10, DiscountType.VALUE)
 
 describe('Update coupon service', () => {
   let repo: FakeCouponRepository

--- a/test/update-coupon.spec.ts
+++ b/test/update-coupon.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { UpdateCouponService } from '../src/services/coupon/update-coupon'
+import { FakeCouponRepository } from './helpers/fake-repositories'
+
+const coupon = { id: 'c1', code: 'C1', description: null, discount: 10, discountType: 'VALUE', imageUrl: null, quantity: 5, unitId: 'unit-1', createdAt: new Date() } as any
+
+describe('Update coupon service', () => {
+  let repo: FakeCouponRepository
+  let service: UpdateCouponService
+
+  beforeEach(() => {
+    repo = new FakeCouponRepository([coupon])
+    service = new UpdateCouponService(repo)
+  })
+
+  it('updates coupon data', async () => {
+    const res = await service.execute({ id: 'c1', data: { quantity: { decrement: 2 } } })
+    expect(res.coupon.quantity).toBe(3)
+  })
+})

--- a/test/update-organization.spec.ts
+++ b/test/update-organization.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { UpdateOrganizationService } from '../src/services/organization/update-organization'
+import { FakeOrganizationRepository } from './helpers/fake-repositories'
+
+const org = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+
+describe('Update organization service', () => {
+  let repo: FakeOrganizationRepository
+  let service: UpdateOrganizationService
+
+  beforeEach(() => {
+    repo = new FakeOrganizationRepository(org, [org])
+    service = new UpdateOrganizationService(repo)
+  })
+
+  it('updates organization data', async () => {
+    const res = await service.execute({ id: 'org-1', name: 'New', slug: 'new' })
+    expect(res.organization.name).toBe('New')
+    expect(repo.organizations[0].slug).toBe('new')
+  })
+})

--- a/test/update-organization.spec.ts
+++ b/test/update-organization.spec.ts
@@ -1,15 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { UpdateOrganizationService } from '../src/services/organization/update-organization'
 import { FakeOrganizationRepository } from './helpers/fake-repositories'
-
-const org = { id: 'org-1', name: 'Org', slug: 'org', ownerId: null, totalBalance: 0, createdAt: new Date() }
+import { defaultOrganization } from './helpers/default-values'
 
 describe('Update organization service', () => {
   let repo: FakeOrganizationRepository
   let service: UpdateOrganizationService
 
   beforeEach(() => {
-    repo = new FakeOrganizationRepository(org, [org])
+    repo = new FakeOrganizationRepository({ ...defaultOrganization }, [{ ...defaultOrganization }])
     service = new UpdateOrganizationService(repo)
   })
 

--- a/test/update-product.spec.ts
+++ b/test/update-product.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { UpdateProductService } from '../src/services/product/update-product'
+import { FakeProductRepository } from './helpers/fake-repositories'
+
+const product = {
+  id: 'p1',
+  name: 'Prod',
+  description: null,
+  imageUrl: null,
+  quantity: 5,
+  cost: 10,
+  price: 20,
+  unitId: 'unit-1',
+} as any
+
+describe('Update product service', () => {
+  let repo: FakeProductRepository
+  let service: UpdateProductService
+
+  beforeEach(() => {
+    repo = new FakeProductRepository([product])
+    service = new UpdateProductService(repo)
+  })
+
+  it('updates product data', async () => {
+    const res = await service.execute({ id: 'p1', data: { name: 'New', quantity: { decrement: 1 } } })
+    expect(res.product.name).toBe('New')
+    expect(repo.products[0].quantity).toBe(4)
+  })
+})

--- a/test/update-product.spec.ts
+++ b/test/update-product.spec.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { UpdateProductService } from '../src/services/product/update-product'
 import { FakeProductRepository } from './helpers/fake-repositories'
+import { makeProduct } from './helpers/default-values'
 
-const product = {
-  id: 'p1',
-  name: 'Prod',
-  description: null,
-  imageUrl: null,
-  quantity: 5,
-  cost: 10,
-  price: 20,
-  unitId: 'unit-1',
-} as any
+const product = makeProduct('p1', 20)
 
 describe('Update product service', () => {
   let repo: FakeProductRepository

--- a/test/update-profile-user-service.spec.ts
+++ b/test/update-profile-user-service.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { UpdateProfileUserService } from '../src/services/profile/update-profile-user-service'
 import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
 import { FakeProfilesRepository } from './helpers/fake-repositories'
+import { makeProfile } from './helpers/default-values'
 import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
 import { ProfileNotFoundError } from '../src/services/@errors/profile-not-found-error'
 
@@ -24,20 +25,7 @@ describe('Update profile user service', () => {
       organization: { connect: { id: 'org-1' } },
       unit: { connect: { id: 'unit-1' } },
     })
-    profileRepo.profiles.push({
-      id: 'p1',
-      phone: '1',
-      cpf: '2',
-      genre: '',
-      birthday: '',
-      pix: '',
-      role: 'BARBER' as any,
-      commissionPercentage: 100,
-      totalBalance: 0,
-      userId: user.id,
-      createdAt: new Date(),
-      user: { ...user, password: '' },
-    })
+    profileRepo.profiles.push({ ...makeProfile('p1', user.id, 0), user: { ...user, password: '' } })
 
     const res = await service.execute({
       id: user.id,

--- a/test/update-profile-user-service.spec.ts
+++ b/test/update-profile-user-service.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { UpdateProfileUserService } from '../src/services/profile/update-profile-user-service'
+import { InMemoryUserRepository } from '../src/repositories/in-memory/in-memory-users-repository'
+import { FakeProfilesRepository } from './helpers/fake-repositories'
+import { UserNotFoundError } from '../src/services/@errors/user-not-found-error'
+import { ProfileNotFoundError } from '../src/services/@errors/profile-not-found-error'
+
+describe('Update profile user service', () => {
+  let userRepo: InMemoryUserRepository
+  let profileRepo: FakeProfilesRepository
+  let service: UpdateProfileUserService
+
+  beforeEach(() => {
+    userRepo = new InMemoryUserRepository()
+    profileRepo = new FakeProfilesRepository()
+    service = new UpdateProfileUserService(userRepo, profileRepo)
+  })
+
+  it('updates profile and user', async () => {
+    const user = await userRepo.create({
+      name: 'John',
+      email: 'j@e.com',
+      password: '123',
+      organization: { connect: { id: 'org-1' } },
+      unit: { connect: { id: 'unit-1' } },
+    })
+    profileRepo.profiles.push({
+      id: 'p1',
+      phone: '1',
+      cpf: '2',
+      genre: '',
+      birthday: '',
+      pix: '',
+      role: 'BARBER' as any,
+      commissionPercentage: 100,
+      totalBalance: 0,
+      userId: user.id,
+      createdAt: new Date(),
+      user: { ...user, password: '' },
+    })
+
+    const res = await service.execute({
+      id: user.id,
+      name: 'New',
+      email: 'new@test.com',
+      active: true,
+      phone: '3',
+      cpf: '4',
+      genre: '',
+      birthday: '',
+      pix: '',
+      role: 'BARBER' as any,
+    })
+
+    expect(res.user?.name).toBe('New')
+    expect(res.profile.phone).toBe('3')
+  })
+
+  it('throws when user not found', async () => {
+    await expect(
+      service.execute({
+        id: 'no',
+        name: '',
+        email: '',
+        active: true,
+        phone: '',
+        cpf: '',
+        genre: '',
+        birthday: '',
+        pix: '',
+        role: 'BARBER' as any,
+      }),
+    ).rejects.toBeInstanceOf(UserNotFoundError)
+  })
+
+  it('throws when profile not found', async () => {
+    const user = await userRepo.create({
+      name: 'John',
+      email: 'j@x.com',
+      password: '123',
+      organization: { connect: { id: 'org-1' } },
+      unit: { connect: { id: 'unit-1' } },
+    })
+
+    await expect(
+      service.execute({
+        id: user.id,
+        name: 'n',
+        email: '',
+        active: true,
+        phone: '',
+        cpf: '',
+        genre: '',
+        birthday: '',
+        pix: '',
+        role: 'BARBER' as any,
+      }),
+    ).rejects.toBeInstanceOf(ProfileNotFoundError)
+  })
+})
+

--- a/test/update-unit.spec.ts
+++ b/test/update-unit.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { UpdateUnitService } from '../src/services/unit/update-unit'
 import { FakeUnitRepository } from './helpers/fake-repositories'
+import { makeUnit } from './helpers/default-values'
 
-const unit = { id: 'unit-1', name: 'A', slug: 'a', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
+const unit = makeUnit('unit-1', 'A', 'a', 'org-1')
 
 describe('Update unit service', () => {
   let repo: FakeUnitRepository

--- a/test/update-unit.spec.ts
+++ b/test/update-unit.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { UpdateUnitService } from '../src/services/unit/update-unit'
+import { FakeUnitRepository } from './helpers/fake-repositories'
+
+const unit = { id: 'unit-1', name: 'A', slug: 'a', organizationId: 'org-1', totalBalance: 0, allowsLoan: false }
+
+describe('Update unit service', () => {
+  let repo: FakeUnitRepository
+  let service: UpdateUnitService
+
+  beforeEach(() => {
+    repo = new FakeUnitRepository(unit, [unit])
+    service = new UpdateUnitService(repo)
+  })
+
+  it('updates unit data', async () => {
+    const result = await service.execute({ id: 'unit-1', name: 'New', allowsLoan: true })
+    expect(result.unit.name).toBe('New')
+    expect(result.unit.allowsLoan).toBe(true)
+    expect(repo.units[0].name).toBe('New')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,7 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  test: {
+    setupFiles: './test/setup.ts',
+  },
 })


### PR DESCRIPTION
## Summary
- implement helper methods in fake repositories for sales, profiles and transactions
- implement in-memory finders for cash register repository
- create new test suites for sales, profile and report services

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fc1316c5c8329875b3d7b46a1f182