### PR TITLE
Add service unit tests

### DIFF
--- a/test/tests/appointment/create-appointment.spec.ts
+++ b/test/tests/appointment/create-appointment.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CreateAppointmentService } from '../../../src/services/appointment/create-appointment'
+import { InMemoryAppointmentRepository } from '../../helpers/fake-repositories'
+
+describe('Create appointment service', () => {
+  let repo: InMemoryAppointmentRepository
+  let service: CreateAppointmentService
+
+  beforeEach(() => {
+    repo = new InMemoryAppointmentRepository()
+    service = new CreateAppointmentService(repo)
+  })
+
+  it('creates appointment', async () => {
+    const res = await service.execute({
+      clientId: 'c1',
+      barberId: 'b1',
+      serviceId: 's1',
+      unitId: 'unit-1',
+      date: new Date('2024-01-01'),
+      hour: '10:00',
+    })
+    expect(repo.appointments).toHaveLength(1)
+    expect(res.appointment.clientId).toBe('c1')
+  })
+})

--- a/test/tests/appointment/list-appointments.spec.ts
+++ b/test/tests/appointment/list-appointments.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListAppointmentsService } from '../../../src/services/appointment/list-appointments'
+import { InMemoryAppointmentRepository } from '../../helpers/fake-repositories'
+
+const a1 = { id: 'a1', unitId: 'unit-1', service: {}, client: {}, barber: {}, date: new Date(), hour: '10', unit: { organizationId: 'org-1' } } as any
+const a2 = { id: 'a2', unitId: 'unit-2', service: {}, client: {}, barber: {}, date: new Date(), hour: '11', unit: { organizationId: 'org-2' } } as any
+
+describe('List appointments service', () => {
+  let repo: InMemoryAppointmentRepository
+  let service: ListAppointmentsService
+
+  beforeEach(() => {
+    repo = new InMemoryAppointmentRepository()
+    repo.appointments.push(a1, a2)
+    service = new ListAppointmentsService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.appointments).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({ sub: '1', role: 'OWNER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.appointments).toHaveLength(1)
+    expect(res.appointments[0].id).toBe('a1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-2', organizationId: 'org-2' } as any)
+    expect(res.appointments).toHaveLength(1)
+    expect(res.appointments[0].id).toBe('a2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(service.execute({ sub: '', role: 'ADMIN', unitId: 'u1', organizationId: 'o1' } as any)).rejects.toThrow('User not found')
+  })
+})

--- a/test/tests/barber-user/delete-user.spec.ts
+++ b/test/tests/barber-user/delete-user.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DeleteUserService } from '../../../src/services/barber-user/delete-user'
+import { InMemoryBarberUsersRepository } from '../../helpers/fake-repositories'
+import { makeUser, makeProfile } from '../../factories/make-user.factory'
+
+function makeStoredUser() {
+  const user = makeUser()
+  const profile = makeProfile({ userId: user.id })
+  return { ...user, profile }
+}
+
+describe('Delete user service', () => {
+  let repo: InMemoryBarberUsersRepository
+  let service: DeleteUserService
+
+  beforeEach(() => {
+    repo = new InMemoryBarberUsersRepository()
+    service = new DeleteUserService(repo)
+  })
+
+  it('deletes user', async () => {
+    const stored = makeStoredUser()
+    repo.users.push(stored as any)
+
+    await service.execute({ id: stored.id })
+    expect(repo.users).toHaveLength(0)
+  })
+})

--- a/test/tests/barber-user/get-user.spec.ts
+++ b/test/tests/barber-user/get-user.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GetUserService } from '../../../src/services/barber-user/get-user'
+import { InMemoryBarberUsersRepository } from '../../helpers/fake-repositories'
+import { makeUser, makeProfile } from '../../factories/make-user.factory'
+
+describe('Get user service', () => {
+  let repo: InMemoryBarberUsersRepository
+  let service: GetUserService
+
+  beforeEach(() => {
+    repo = new InMemoryBarberUsersRepository()
+    service = new GetUserService(repo)
+  })
+
+  it('returns user by id', async () => {
+    const user = makeUser()
+    const profile = makeProfile({ userId: user.id })
+    repo.users.push({ ...user, profile } as any)
+
+    const res = await service.execute({ id: user.id })
+    expect(res.user?.id).toBe(user.id)
+  })
+
+  it('returns null when not found', async () => {
+    const res = await service.execute({ id: 'no' })
+    expect(res.user).toBeNull()
+  })
+})

--- a/test/tests/barber-user/list-users.spec.ts
+++ b/test/tests/barber-user/list-users.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListUsersService } from '../../../src/services/barber-user/list-users'
+import { InMemoryBarberUsersRepository } from '../../helpers/fake-repositories'
+
+const u1 = { id: 'u1', email: 'a@a.com', profile: null, unit: { id: 'unit-1' }, organizationId: 'org-1' } as any
+const u2 = { id: 'u2', email: 'b@b.com', profile: null, unit: { id: 'unit-2' }, organizationId: 'org-2' } as any
+
+describe('List users service', () => {
+  let repo: InMemoryBarberUsersRepository
+  let service: ListUsersService
+
+  beforeEach(() => {
+    repo = new InMemoryBarberUsersRepository([u1, u2])
+    service = new ListUsersService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({ sub: '1', role: 'ADMIN', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.users).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({ sub: '1', role: 'OWNER', unitId: 'unit-1', organizationId: 'org-1' } as any)
+    expect(res.users).toHaveLength(1)
+    expect(res.users[0].id).toBe('u1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({ sub: '1', role: 'BARBER', unitId: 'unit-2', organizationId: 'org-2' } as any)
+    expect(res.users).toHaveLength(1)
+    expect(res.users[0].id).toBe('u2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(service.execute({ sub: '', role: 'ADMIN', unitId: 'u1', organizationId: 'o1' } as any)).rejects.toThrow('User not found')
+  })
+})

--- a/test/tests/barber-user/register-user.spec.ts
+++ b/test/tests/barber-user/register-user.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { RegisterUserService } from '../../../src/services/barber-user/register-user'
+import { InMemoryBarberUsersRepository, FakeUnitRepository } from '../../helpers/fake-repositories'
+import { defaultUnit } from '../../helpers/default-values'
+
+const baseData = {
+  name: 'John',
+  email: 'j@e.com',
+  password: '123',
+  phone: '1',
+  cpf: '2',
+  genre: 'M',
+  birthday: '2000',
+  pix: 'x',
+  role: 'BARBER' as any,
+}
+
+describe('Register user service', () => {
+  let repo: InMemoryBarberUsersRepository
+  let unitRepo: FakeUnitRepository
+  let service: RegisterUserService
+
+  beforeEach(() => {
+    repo = new InMemoryBarberUsersRepository()
+    unitRepo = new FakeUnitRepository({ ...defaultUnit }, [{ ...defaultUnit }])
+    service = new RegisterUserService(repo, unitRepo)
+  })
+
+  it('creates user and profile', async () => {
+    const res = await service.execute({ ...baseData, unitId: defaultUnit.id })
+    expect(repo.users).toHaveLength(1)
+    expect(res.profile.userId).toBe(res.user.id)
+  })
+
+  it('throws when email already exists', async () => {
+    await service.execute({ ...baseData, unitId: defaultUnit.id })
+    await expect(service.execute({ ...baseData, unitId: defaultUnit.id })).rejects.toThrow('User already exists')
+  })
+
+  it('throws when unit not exists', async () => {
+    const badUnit = new FakeUnitRepository({ ...defaultUnit, id: 'x' }, [])
+    service = new RegisterUserService(repo, badUnit)
+    await expect(service.execute({ ...baseData, unitId: 'x' })).rejects.toThrow('Unit not exists')
+  })
+})

--- a/test/tests/barber-user/update-user.spec.ts
+++ b/test/tests/barber-user/update-user.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { UpdateUserService } from '../../../src/services/barber-user/update-user'
+import { InMemoryBarberUsersRepository, FakeUnitRepository } from '../../helpers/fake-repositories'
+import { defaultUnit } from '../../helpers/default-values'
+import { makeUser, makeProfile } from '../../factories/make-user.factory'
+
+describe('Update user service', () => {
+  let repo: InMemoryBarberUsersRepository
+  let unitRepo: FakeUnitRepository
+  let service: UpdateUserService
+  let stored: any
+
+  beforeEach(() => {
+    repo = new InMemoryBarberUsersRepository()
+    unitRepo = new FakeUnitRepository({ ...defaultUnit }, [{ ...defaultUnit }])
+    service = new UpdateUserService(repo, unitRepo)
+    const user = makeUser()
+    const profile = makeProfile({ userId: user.id })
+    stored = { ...user, profile }
+    repo.users.push(stored)
+  })
+
+  it('updates user data', async () => {
+    const res = await service.execute({ id: stored.id, name: 'New', phone: '9' })
+    expect(res.user.name).toBe('New')
+    expect(res.profile?.phone).toBe('9')
+  })
+
+  it('updates unit when provided', async () => {
+    const unit = { ...defaultUnit, id: 'u2' }
+    unitRepo.units.push(unit)
+    const res = await service.execute({ id: stored.id, unitId: 'u2' })
+    expect(res.user.unitId).toBe('u2')
+  })
+
+  it('throws when user not found', async () => {
+    await expect(service.execute({ id: 'x' })).rejects.toThrow('User not found')
+  })
+
+  it('throws when unit not exists', async () => {
+    await expect(service.execute({ id: stored.id, unitId: 'bad' })).rejects.toThrow('Unit not exists')
+  })
+})

--- a/test/tests/cash-register/close-session.spec.ts
+++ b/test/tests/cash-register/close-session.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CloseSessionService } from '../../../src/services/cash-register/close-session'
+import { InMemoryCashRegisterRepository } from '../../helpers/fake-repositories'
+import { TransactionType } from '@prisma/client'
+
+function makeSession() {
+  return {
+    id: 's1',
+    openedById: 'u1',
+    unitId: 'unit-1',
+    openedAt: new Date(),
+    closedAt: null,
+    initialAmount: 0,
+    finalAmount: null,
+    user: {} as any,
+    sales: [],
+    transactions: [
+      {
+        id: 't1',
+        userId: 'u1',
+        affectedUserId: null,
+        unitId: 'unit-1',
+        cashRegisterSessionId: 's1',
+        type: TransactionType.ADDITION,
+        description: '',
+        amount: 100,
+        createdAt: new Date(),
+      },
+      {
+        id: 't2',
+        userId: 'u1',
+        affectedUserId: null,
+        unitId: 'unit-1',
+        cashRegisterSessionId: 's1',
+        type: TransactionType.WITHDRAWAL,
+        description: '',
+        amount: 40,
+        createdAt: new Date(),
+      },
+    ],
+  } as any
+}
+
+describe('Close session service', () => {
+  let repo: InMemoryCashRegisterRepository
+  let service: CloseSessionService
+
+  beforeEach(() => {
+    repo = new InMemoryCashRegisterRepository()
+    service = new CloseSessionService(repo)
+  })
+
+  it('closes an open session calculating final amount', async () => {
+    const session = makeSession()
+    repo.sessions.push(session)
+
+    const res = await service.execute({ unitId: 'unit-1' })
+    expect(res.session.finalAmount).toBe(60)
+    expect(repo.sessions[0].closedAt).toBeInstanceOf(Date)
+  })
+
+  it('throws when there is no open session', async () => {
+    await expect(service.execute({ unitId: 'unit-1' })).rejects.toThrow(
+      'Cash register not opened',
+    )
+  })
+})

--- a/test/tests/cash-register/list-sessions.spec.ts
+++ b/test/tests/cash-register/list-sessions.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ListSessionsService } from '../../../src/services/cash-register/list-sessions'
+import { InMemoryCashRegisterRepository } from '../../helpers/fake-repositories'
+
+const s1 = {
+  id: 's1',
+  openedById: 'u1',
+  unitId: 'unit-1',
+  openedAt: new Date(),
+  closedAt: null,
+  initialAmount: 0,
+  finalAmount: null,
+  user: {},
+  sales: [],
+  transactions: [],
+  unit: { organizationId: 'org-1' },
+} as any
+
+const s2 = {
+  id: 's2',
+  openedById: 'u2',
+  unitId: 'unit-2',
+  openedAt: new Date(),
+  closedAt: null,
+  initialAmount: 0,
+  finalAmount: null,
+  user: {},
+  sales: [],
+  transactions: [],
+  unit: { organizationId: 'org-2' },
+} as any
+
+describe('List sessions service', () => {
+  let repo: InMemoryCashRegisterRepository
+  let service: ListSessionsService
+
+  beforeEach(() => {
+    repo = new InMemoryCashRegisterRepository()
+    repo.sessions.push(s1, s2)
+    service = new ListSessionsService(repo)
+  })
+
+  it('lists all for admin', async () => {
+    const res = await service.execute({
+      sub: '1',
+      role: 'ADMIN',
+      unitId: 'unit-1',
+      organizationId: 'org-1',
+    } as any)
+    expect(res.sessions).toHaveLength(2)
+  })
+
+  it('filters by organization for owner', async () => {
+    const res = await service.execute({
+      sub: '1',
+      role: 'OWNER',
+      unitId: 'unit-1',
+      organizationId: 'org-1',
+    } as any)
+    expect(res.sessions).toHaveLength(1)
+    expect(res.sessions[0].id).toBe('s1')
+  })
+
+  it('filters by unit for others', async () => {
+    const res = await service.execute({
+      sub: '1',
+      role: 'BARBER',
+      unitId: 'unit-2',
+      organizationId: 'org-2',
+    } as any)
+    expect(res.sessions).toHaveLength(1)
+    expect(res.sessions[0].id).toBe('s2')
+  })
+
+  it('throws if user not found', async () => {
+    await expect(
+      service.execute({ sub: '', role: 'ADMIN', unitId: 'u1', organizationId: 'o1' } as any),
+    ).rejects.toThrow('User not found')
+  })
+})


### PR DESCRIPTION
## Summary
- implement in-memory repositories for tests
- add unit tests for cash register services
- add unit tests for barber user services
- add unit tests for appointments

## Testing
- `npx vitest run` *(fails: packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68507209870c83299e4dd3e628b41d38