### PR TITLE
Update sale transaction handling

### DIFF
--- a/prisma/migrations/20250621000000_sale_multiple_transactions/migration.sql
+++ b/prisma/migrations/20250621000000_sale_multiple_transactions/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE `transactions` ADD COLUMN `saleId` VARCHAR(191);
+
+-- AddForeignKey
+ALTER TABLE `transactions` ADD CONSTRAINT `transactions_saleId_fkey` FOREIGN KEY (`saleId`) REFERENCES `sales`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE `sales` DROP FOREIGN KEY `sales_transactionId_fkey`;
+ALTER TABLE `sales` DROP INDEX `sales_transactionId_key`;
+ALTER TABLE `sales` DROP COLUMN `transactionId`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,8 @@ model Transaction {
   receiptUrl            String?
   createdAt             DateTime        @default(now())
 
-  sale Sale?
+  saleId String?
+  sale   Sale?          @relation(fields: [saleId], references: [id])
 
   user         User                 @relation(fields: [userId], references: [id])
   affectedUser User?                @relation("AffectedUser", fields: [affectedUserId], references: [id])
@@ -160,19 +161,18 @@ model Sale {
   unitId        String
   sessionId     String?
   couponId      String?
-  transactionId String?       @unique
   total         Float
   method        PaymentMethod
   paymentStatus PaymentStatus @default(PAID)
   createdAt     DateTime      @default(now())
 
-  user        User                 @relation(fields: [userId], references: [id])
-  client      User                 @relation("SaleClient", fields: [clientId], references: [id])
-  items       SaleItem[]
-  unit        Unit                 @relation(fields: [unitId], references: [id])
-  coupon      Coupon?              @relation(fields: [couponId], references: [id])
-  session     CashRegisterSession? @relation(fields: [sessionId], references: [id])
-  transaction Transaction?         @relation(fields: [transactionId], references: [id])
+  user         User                 @relation(fields: [userId], references: [id])
+  client       User                 @relation("SaleClient", fields: [clientId], references: [id])
+  items        SaleItem[]
+  unit         Unit                 @relation(fields: [unitId], references: [id])
+  coupon       Coupon?              @relation(fields: [couponId], references: [id])
+  session      CashRegisterSession? @relation(fields: [sessionId], references: [id])
+  transactions Transaction[]
 
   @@map("sales")
 }

--- a/src/repositories/prisma/prisma-sale-repository.ts
+++ b/src/repositories/prisma/prisma-sale-repository.ts
@@ -19,7 +19,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -40,7 +40,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -61,7 +61,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -86,7 +86,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -107,7 +107,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -128,7 +128,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -149,7 +149,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }
@@ -170,7 +170,7 @@ export class PrismaSaleRepository implements SaleRepository {
         client: { include: { profile: true } },
         coupon: true,
         session: true,
-        transaction: true,
+        transactions: true,
       },
     })
   }

--- a/src/repositories/prisma/seed.ts
+++ b/src/repositories/prisma/seed.ts
@@ -254,17 +254,6 @@ async function main() {
     data: { totalBalance: { increment: 100 } },
   })
 
-  const transaction = await prisma.transaction.create({
-    data: {
-      userId: client.id,
-      unitId: mainUnit.id,
-      cashRegisterSessionId: cashSession.id,
-      type: TransactionType.ADDITION,
-      description: 'Sale',
-      amount: 35,
-      receiptUrl: '/uploads/sample-receipt.png',
-    },
-  })
   await prisma.unit.update({
     where: { id: mainUnit.id },
     data: { totalBalance: { increment: 35 } },
@@ -304,7 +293,6 @@ async function main() {
           },
         ],
       },
-      transaction: { connect: { id: transaction.id } },
     },
   })
   const pendingSale = await prisma.sale.create({

--- a/src/repositories/sale-repository.ts
+++ b/src/repositories/sale-repository.ts
@@ -29,7 +29,7 @@ export type DetailedSale = Sale & {
   client: User & { profile: Profile | null }
   coupon: Coupon | null
   session: CashRegisterSession | null
-  transaction: Transaction | null
+  transactions: Transaction[]
 }
 
 export interface SaleRepository {

--- a/src/services/sale/create-sale.ts
+++ b/src/services/sale/create-sale.ts
@@ -2,12 +2,7 @@ import { SaleRepository } from '../../repositories/sale-repository'
 import { ServiceRepository } from '../../repositories/service-repository'
 import { ProductRepository } from '../../repositories/product-repository'
 import { CouponRepository } from '../../repositories/coupon-repository'
-import {
-  DiscountType,
-  TransactionType,
-  PaymentStatus,
-  Transaction,
-} from '@prisma/client'
+import { DiscountType, PaymentStatus } from '@prisma/client'
 import { BarberUsersRepository } from '@/repositories/barber-users-repository'
 import { CashRegisterRepository } from '@/repositories/cash-register-repository'
 import { TransactionRepository } from '@/repositories/transaction-repository'
@@ -216,25 +211,6 @@ export class CreateSaleService {
     return tempItems.reduce((acc, i) => acc + i.price, 0)
   }
 
-  private async createTransactionIfPaid(
-    paymentStatus: PaymentStatus,
-    userId: string,
-    unitId: string | undefined,
-    session: { id: string } | null,
-    amount: number,
-  ): Promise<Transaction | null> {
-    if (paymentStatus !== PaymentStatus.PAID) return null
-
-    return this.transactionRepository.create({
-      user: { connect: { id: userId } },
-      unit: { connect: { id: unitId } },
-      session: session ? { connect: { id: session.id } } : undefined,
-      type: TransactionType.ADDITION,
-      description: 'Sale',
-      amount,
-    })
-  }
-
   private async updateProductsStock(
     products: { id: string; quantity: number }[],
   ): Promise<void> {
@@ -285,47 +261,32 @@ export class CreateSaleService {
     const saleItems = this.mapToSaleItems(tempItems)
     const calculatedTotal = this.calculateTotal(tempItems)
 
-    const transaction = await this.createTransactionIfPaid(
+    const sale = await this.saleRepository.create({
+      total: calculatedTotal,
+      method,
       paymentStatus,
-      userId,
-      user?.unitId,
-      session,
-      calculatedTotal,
-    )
-
-    try {
-      const sale = await this.saleRepository.create({
-        total: calculatedTotal,
-        method,
-        paymentStatus,
-        user: { connect: { id: userId } },
-        client: { connect: { id: clientId } },
-        unit: { connect: { id: user?.unitId } },
-        session:
-          paymentStatus === PaymentStatus.PAID && session
-            ? { connect: { id: session.id } }
-            : undefined,
-        items: { create: saleItems },
-        coupon: couponConnect,
-        transaction: transaction
-          ? { connect: { id: transaction.id } }
+      user: { connect: { id: userId } },
+      client: { connect: { id: clientId } },
+      unit: { connect: { id: user?.unitId } },
+      session:
+        paymentStatus === PaymentStatus.PAID && session
+          ? { connect: { id: session.id } }
           : undefined,
+      items: { create: saleItems },
+      coupon: couponConnect,
+    })
+
+    if (paymentStatus === PaymentStatus.PAID) {
+      await distributeProfits(sale, user?.organizationId as string, userId, {
+        organizationRepository: this.organizationRepository,
+        profileRepository: this.profileRepository,
+        unitRepository: this.unitRepository,
+        transactionRepository: this.transactionRepository,
       })
-
-      if (paymentStatus === PaymentStatus.PAID) {
-        await distributeProfits(sale, user?.organizationId as string, {
-          organizationRepository: this.organizationRepository,
-          profileRepository: this.profileRepository,
-          unitRepository: this.unitRepository,
-        })
-      }
-
-      await this.updateProductsStock(productsToUpdate)
-
-      return { sale }
-    } catch (error) {
-      if (transaction) await this.transactionRepository.delete(transaction.id)
-      throw error
     }
+
+    await this.updateProductsStock(productsToUpdate)
+
+    return { sale }
   }
 }

--- a/src/services/sale/profit-distribution.ts
+++ b/src/services/sale/profit-distribution.ts
@@ -1,15 +1,20 @@
 import { DistributeProfitsDeps } from './types'
+import { TransactionType } from '@prisma/client'
 
 import { DetailedSale } from '@/repositories/sale-repository'
 
 export async function distributeProfits(
   sale: DetailedSale,
   organizationId: string,
+  userId: string,
   {
     organizationRepository,
     profileRepository,
     unitRepository,
-  }: DistributeProfitsDeps,
+    transactionRepository,
+  }: DistributeProfitsDeps & {
+    transactionRepository: import('@/repositories/transaction-repository').TransactionRepository
+  },
 ): Promise<void> {
   const org = await organizationRepository.findById(organizationId)
   if (!org) throw new Error('Org not found')
@@ -42,16 +47,70 @@ export async function distributeProfits(
       const valueCalculated = balanceBarber + amount
       if (valueCalculated <= 0) {
         await unitRepository.incrementBalance(sale.unitId, amount)
+        await transactionRepository.create({
+          user: { connect: { id: userId } },
+          unit: { connect: { id: sale.unitId } },
+          session: { connect: { id: sale.sessionId! } },
+          sale: { connect: { id: sale.id } },
+          type: TransactionType.ADDITION,
+          description: 'Sale',
+          amount,
+        })
       } else {
         await unitRepository.incrementBalance(sale.unitId, balanceBarber * -1)
+        await transactionRepository.create({
+          user: { connect: { id: userId } },
+          unit: { connect: { id: sale.unitId } },
+          session: { connect: { id: sale.sessionId! } },
+          sale: { connect: { id: sale.id } },
+          type: TransactionType.ADDITION,
+          description: 'Sale',
+          amount: balanceBarber * -1,
+        })
         await organizationRepository.incrementBalance(
           org.id,
           balanceBarber * -1,
         )
+        await transactionRepository.create({
+          user: { connect: { id: userId } },
+          unit: { connect: { id: sale.unitId } },
+          session: { connect: { id: sale.sessionId! } },
+          sale: { connect: { id: sale.id } },
+          type: TransactionType.ADDITION,
+          description: 'Sale',
+          amount: balanceBarber * -1,
+        })
       }
     }
     await profileRepository.incrementBalance(barberId, amount)
+    await transactionRepository.create({
+      user: { connect: { id: barberId } },
+      unit: { connect: { id: sale.unitId } },
+      session: { connect: { id: sale.sessionId! } },
+      sale: { connect: { id: sale.id } },
+      type: TransactionType.ADDITION,
+      description: 'Sale',
+      amount,
+    })
   }
   await unitRepository.incrementBalance(sale.unitId, ownerShare)
+  await transactionRepository.create({
+    user: { connect: { id: userId } },
+    unit: { connect: { id: sale.unitId } },
+    session: { connect: { id: sale.sessionId! } },
+    sale: { connect: { id: sale.id } },
+    type: TransactionType.ADDITION,
+    description: 'Sale',
+    amount: ownerShare,
+  })
   await organizationRepository.incrementBalance(org.id, ownerShare)
+  await transactionRepository.create({
+    user: { connect: { id: userId } },
+    unit: { connect: { id: sale.unitId } },
+    session: { connect: { id: sale.sessionId! } },
+    sale: { connect: { id: sale.id } },
+    type: TransactionType.ADDITION,
+    description: 'Sale',
+    amount: ownerShare,
+  })
 }

--- a/src/services/sale/set-sale-status.ts
+++ b/src/services/sale/set-sale-status.ts
@@ -5,7 +5,7 @@ import { TransactionRepository } from '@/repositories/transaction-repository'
 import { OrganizationRepository } from '@/repositories/organization-repository'
 import { ProfilesRepository } from '@/repositories/profiles-repository'
 import { UnitRepository } from '@/repositories/unit-repository'
-import { PaymentStatus, TransactionType } from '@prisma/client'
+import { PaymentStatus } from '@prisma/client'
 import { distributeProfits } from './profit-distribution'
 import { SetSaleStatusRequest, SetSaleStatusResponse } from './types'
 
@@ -39,33 +39,24 @@ export class SetSaleStatusService {
       )
       if (!session) throw new Error('Cash register closed')
 
-      const transaction = await this.transactionRepository.create({
-        user: { connect: { id: userId } },
-        unit: { connect: { id: user?.unitId } },
+      const updatedSale = await this.saleRepository.update(saleId, {
+        paymentStatus,
         session: { connect: { id: session.id } },
-        type: TransactionType.ADDITION,
-        description: 'Sale',
-        amount: sale.total,
       })
 
-      try {
-        const updatedSale = await this.saleRepository.update(saleId, {
-          paymentStatus,
-          session: { connect: { id: session.id } },
-          transaction: { connect: { id: transaction.id } },
-        })
-
-        await distributeProfits(updatedSale, user?.organizationId as string, {
+      await distributeProfits(
+        updatedSale,
+        user?.organizationId as string,
+        userId,
+        {
           organizationRepository: this.organizationRepository,
           profileRepository: this.profileRepository,
           unitRepository: this.unitRepository,
-        })
+          transactionRepository: this.transactionRepository,
+        },
+      )
 
-        return { sale: updatedSale }
-      } catch (error) {
-        await this.transactionRepository.delete(transaction.id)
-        throw error
-      }
+      return { sale: updatedSale }
     }
 
     const updatedSale = await this.saleRepository.update(saleId, {

--- a/src/services/sale/types.ts
+++ b/src/services/sale/types.ts
@@ -10,6 +10,7 @@ export interface DistributeProfitsDeps {
   organizationRepository: import('@/repositories/organization-repository').OrganizationRepository
   profileRepository: import('@/repositories/profiles-repository').ProfilesRepository
   unitRepository: import('@/repositories/unit-repository').UnitRepository
+  transactionRepository: import('@/repositories/transaction-repository').TransactionRepository
 }
 
 export interface CreateSaleItem {

--- a/test/helpers/default-values.ts
+++ b/test/helpers/default-values.ts
@@ -204,7 +204,7 @@ export function makeSale(
     client: {},
     coupon: null,
     session: null,
-    transaction: null,
+    transactions: [],
     unit: { organizationId },
   } as any
 }
@@ -242,7 +242,7 @@ export function makeSaleWithBarber(): any {
     client: { ...defaultUser },
     coupon: null,
     session: null,
-    transaction: null,
+    transactions: [],
   } as any
 }
 

--- a/test/helpers/fake-repositories.ts
+++ b/test/helpers/fake-repositories.ts
@@ -575,7 +575,6 @@ export class FakeSaleRepository implements SaleRepository {
       unitId: (data.unit as any).connect.id,
       sessionId: (data.session as any)?.connect.id,
       couponId: (data.coupon as any)?.connect.id,
-      transactionId: (data.transaction as any)?.connect.id,
       total: data.total as number,
       method: data.method as PaymentMethod,
       paymentStatus: data.paymentStatus as PaymentStatus,
@@ -617,19 +616,7 @@ export class FakeSaleRepository implements SaleRepository {
           }
         : null,
       session: null,
-      transaction: data.transaction
-        ? {
-            id: (data.transaction as any).connect.id,
-            userId: '',
-            affectedUserId: null,
-            unitId: '',
-            cashRegisterSessionId: '',
-            type: TransactionType.ADDITION,
-            description: '',
-            amount: data.total as number,
-            createdAt: new Date(),
-          }
-        : null,
+      transactions: [],
     }
     this.sales.push(sale)
     return sale
@@ -670,21 +657,7 @@ export class FakeSaleRepository implements SaleRepository {
         finalAmount: null,
       }
     }
-    if (data.transaction && 'connect' in data.transaction!) {
-      const tid = (data.transaction as any).connect.id
-      sale.transactionId = tid
-      sale.transaction = {
-        id: tid,
-        userId: '',
-        affectedUserId: null,
-        unitId: sale.unitId,
-        cashRegisterSessionId: sale.sessionId ?? '',
-        type: TransactionType.ADDITION,
-        description: '',
-        amount: sale.total,
-        createdAt: new Date(),
-      }
-    }
+    sale.transactions = sale.transactions ?? []
     return sale
   }
 

--- a/test/tests/sale/set-sale-status.spec.ts
+++ b/test/tests/sale/set-sale-status.spec.ts
@@ -91,7 +91,7 @@ describe('Set sale status service', () => {
       paymentStatus: PaymentStatus.PAID,
     })
     expect(res.sale.paymentStatus).toBe(PaymentStatus.PAID)
-    expect(transactionRepo.transactions).toHaveLength(1)
+    expect(transactionRepo.transactions).toHaveLength(3)
     expect(profileRepo.profiles[0].totalBalance).toBeCloseTo(50)
     expect(unitRepo.unit.totalBalance).toBeCloseTo(50)
     expect(orgRepo.organization.totalBalance).toBeCloseTo(50)


### PR DESCRIPTION
## Summary
- change Prisma schema to let sales have multiple transactions
- create new migration for updated relation
- adjust sale repository implementations
- remove pre-sale transaction creation
- generate transactions during profit distribution
- update tests and fake repositories

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ef93c0948329849c94678c5067af