### PR TITLE
Remove ownerId from Organization

### DIFF
--- a/prisma/migrations/20250618170000_remove_owner_id/migration.sql
+++ b/prisma/migrations/20250618170000_remove_owner_id/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `organizations` DROP FOREIGN KEY `organizations_ownerId_fkey`;
+ALTER TABLE `organizations` DROP COLUMN `ownerId`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,7 +57,6 @@ model User {
   affectedTransactions Transaction[]         @relation("AffectedUser")
   sessions             CashRegisterSession[]
   passwordResetTokens  PasswordResetToken[]
-  ownedOrganizations   Organization[]        @relation("OrganizationOwner")
   createdAt            DateTime              @default(now())
 
   organization Organization @relation(fields: [organizationId], references: [id])
@@ -252,8 +251,6 @@ model Organization {
   id           String   @id @default(uuid())
   name         String
   slug         String   @unique
-  ownerId      String?
-  owner        User?    @relation("OrganizationOwner", fields: [ownerId], references: [id])
   users        User[]
   units        Unit[]
   totalBalance Float    @default(0)

--- a/src/repositories/prisma/seed.ts
+++ b/src/repositories/prisma/seed.ts
@@ -89,11 +89,6 @@ async function main() {
     },
   })
 
-  await prisma.organization.update({
-    where: { id: organization.id },
-    data: { owner: { connect: { id: owner.id } } },
-  })
-
   const admin = await prisma.user.create({
     data: {
       name: 'Admin',

--- a/test/helpers/default-values.ts
+++ b/test/helpers/default-values.ts
@@ -124,7 +124,6 @@ export const defaultOrganization: Organization = {
   id: 'org-1',
   name: 'Org',
   slug: 'org',
-  ownerId: null,
   totalBalance: 0,
   createdAt: new Date(),
 }
@@ -189,7 +188,6 @@ export function makeOrganization(
     id,
     name,
     slug,
-    ownerId: null,
     totalBalance: 0,
     createdAt: new Date(),
   }

--- a/test/helpers/fake-repositories.ts
+++ b/test/helpers/fake-repositories.ts
@@ -352,7 +352,6 @@ export class FakeOrganizationRepository implements OrganizationRepository {
       id: randomUUID(),
       name: data.name,
       slug: data.slug,
-      ownerId: null,
       totalBalance: 0,
       createdAt: new Date(),
     }

--- a/test/tests/sale/create-sale.spec.ts
+++ b/test/tests/sale/create-sale.spec.ts
@@ -49,7 +49,6 @@ function setup() {
     id: 'org-1',
     name: 'Org',
     slug: 'org',
-    ownerId: null,
     totalBalance: 0,
     createdAt: new Date(),
   }


### PR DESCRIPTION
## Summary
- drop owner relation from Prisma schema
- adjust seed for organization owners
- update test helpers and fixtures
- add migration to drop ownerId

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68533c4f3d4c83298dc0328443ed4179