### PR TITLE
Refactor controllers to rely on global error handler

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import { uploadDir, upload } from './lib/upload'
 import { ZodError } from 'zod'
 import { env } from './env'
+import { handleControllerError } from './utils/http-error-handler'
 import { profileRoute } from './http/controllers/profile/route'
 import { barberShopServiceRoute } from './http/controllers/barber-shop/route'
 import { productRoute } from './http/controllers/product/route'
@@ -129,9 +130,9 @@ app.register(saleRoute)
 app.register(reportRoute)
 app.register(configRoute)
 
-app.setErrorHandler((error, _, replay) => {
+app.setErrorHandler((error, _, reply) => {
   if (error instanceof ZodError) {
-    return replay
+    return reply
       .status(400)
       .send({ message: 'Validation error', issues: error.format() })
   }
@@ -140,5 +141,5 @@ app.setErrorHandler((error, _, replay) => {
     console.log(error)
   }
 
-  return replay.status(500).send({ message: 'Internal server error' })
+  return handleControllerError(error, reply)
 })

--- a/src/http/controllers/appointment/create-appointment-controller.ts
+++ b/src/http/controllers/appointment/create-appointment-controller.ts
@@ -1,33 +1,33 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateAppointment } from '@/services/@factories/appointment/make-create-appointment'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateAppointmentController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      clientId: z.string(),
-      barberId: z.string(),
-      serviceId: z.string(),
-      date: z.coerce.date(),
-      unitId: z.string().optional(),
-      hour: z.string(),
-    })
+export const CreateAppointmentController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    clientId: z.string(),
+    barberId: z.string(),
+    serviceId: z.string(),
+    date: z.coerce.date(),
+    unitId: z.string().optional(),
+    hour: z.string(),
+  })
 
-    const data = bodySchema.parse(request.body)
+  const data = bodySchema.parse(request.body)
 
-    const service = makeCreateAppointment()
-    const unitId = data.unitId ?? (request.user as UserToken).unitId
-    const { appointment } = await service.execute({
-      clientId: data.clientId,
-      barberId: data.barberId,
-      serviceId: data.serviceId,
-      date: data.date,
-      hour: data.hour,
-      unitId,
-    })
+  const service = makeCreateAppointment()
+  const unitId = data.unitId ?? (request.user as UserToken).unitId
+  const { appointment } = await service.execute({
+    clientId: data.clientId,
+    barberId: data.barberId,
+    serviceId: data.serviceId,
+    date: data.date,
+    hour: data.hour,
+    unitId,
+  })
 
-    return reply.status(201).send(appointment)
-  },
-)
+  return reply.status(201).send(appointment)
+}

--- a/src/http/controllers/appointment/list-appointments-controller.ts
+++ b/src/http/controllers/appointment/list-appointments-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListAppointments } from '@/services/@factories/appointment/make-list-appointments'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListAppointmentsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListAppointments()
-    const user = request.user as UserToken
-    const { appointments } = await service.execute(user)
-    return reply.status(200).send(appointments)
-  },
-)
+export const ListAppointmentsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListAppointments()
+  const user = request.user as UserToken
+  const { appointments } = await service.execute(user)
+  return reply.status(200).send(appointments)
+}

--- a/src/http/controllers/barber-shop/create-service-controller.ts
+++ b/src/http/controllers/barber-shop/create-service-controller.ts
@@ -1,32 +1,32 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateService } from '@/services/@factories/barbershop/make-create-service'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateServiceController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string(),
-      description: z.string().optional(),
-      cost: z.coerce.number(),
-      price: z.coerce.number(),
-    })
+export const CreateServiceController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    cost: z.coerce.number(),
+    price: z.coerce.number(),
+  })
 
-    const data = bodySchema.parse(request.body)
+  const data = bodySchema.parse(request.body)
 
-    const imageUrl = request.file
-      ? `/uploads/${request.file.filename}`
-      : undefined
+  const imageUrl = request.file
+    ? `/uploads/${request.file.filename}`
+    : undefined
 
-    const serviceCreator = makeCreateService()
-    const unitId = (request.user as UserToken).unitId
-    const { service } = await serviceCreator.execute({
-      ...data,
-      imageUrl,
-      unitId,
-    })
+  const serviceCreator = makeCreateService()
+  const unitId = (request.user as UserToken).unitId
+  const { service } = await serviceCreator.execute({
+    ...data,
+    imageUrl,
+    unitId,
+  })
 
-    return reply.status(201).send(service)
-  },
-)
+  return reply.status(201).send(service)
+}

--- a/src/http/controllers/barber-shop/list-services-controller.ts
+++ b/src/http/controllers/barber-shop/list-services-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListServices } from '@/services/@factories/barbershop/make-list-services'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListServicesController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListServices()
-    const userToken = request.user as UserToken
-    const { services } = await service.execute(userToken)
-    return reply.status(200).send(services)
-  },
-)
+export const ListServicesController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListServices()
+  const userToken = request.user as UserToken
+  const { services } = await service.execute(userToken)
+  return reply.status(200).send(services)
+}

--- a/src/http/controllers/barber-user/create-user-controller.ts
+++ b/src/http/controllers/barber-user/create-user-controller.ts
@@ -1,50 +1,50 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeRegisterUserService } from '@/services/@factories/barber-user/make-register-user'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { Role } from '@prisma/client'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateBarberUserController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string(),
-      email: z.string().email(),
-      password: z.string().min(6),
-      phone: z.string(),
-      cpf: z.string(),
-      genre: z.string(),
-      birthday: z.string(),
-      pix: z.string(),
-      unitId: z.string().optional(),
-      role: z.nativeEnum(Role),
-    })
+export const CreateBarberUserController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string(),
+    email: z.string().email(),
+    password: z.string().min(6),
+    phone: z.string(),
+    cpf: z.string(),
+    genre: z.string(),
+    birthday: z.string(),
+    pix: z.string(),
+    unitId: z.string().optional(),
+    role: z.nativeEnum(Role),
+  })
 
-    const data = bodySchema.parse(request.body)
-    const service = makeRegisterUserService()
-    const userToken = request.user as UserToken
-    if (
-      (data.role === 'ADMIN' || data.role === 'OWNER') &&
-      userToken.role !== 'ADMIN'
-    ) {
-      return reply.status(403).send({ message: 'Unauthorized' })
-    }
-    let unitId = userToken.unitId
-    if (userToken.role === 'ADMIN') {
-      unitId = data.unitId ?? unitId
-    }
-    const { user, profile } = await service.execute({
-      name: data.name,
-      email: data.email,
-      password: data.password,
-      phone: data.phone,
-      cpf: data.cpf,
-      genre: data.genre,
-      birthday: data.birthday,
-      pix: data.pix,
-      role: data.role,
-      unitId,
-    })
-    return reply.status(201).send({ user, profile })
-  },
-)
+  const data = bodySchema.parse(request.body)
+  const service = makeRegisterUserService()
+  const userToken = request.user as UserToken
+  if (
+    (data.role === 'ADMIN' || data.role === 'OWNER') &&
+    userToken.role !== 'ADMIN'
+  ) {
+    return reply.status(403).send({ message: 'Unauthorized' })
+  }
+  let unitId = userToken.unitId
+  if (userToken.role === 'ADMIN') {
+    unitId = data.unitId ?? unitId
+  }
+  const { user, profile } = await service.execute({
+    name: data.name,
+    email: data.email,
+    password: data.password,
+    phone: data.phone,
+    cpf: data.cpf,
+    genre: data.genre,
+    birthday: data.birthday,
+    pix: data.pix,
+    role: data.role,
+    unitId,
+  })
+  return reply.status(201).send({ user, profile })
+}

--- a/src/http/controllers/barber-user/delete-user-controller.ts
+++ b/src/http/controllers/barber-user/delete-user-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeDeleteUserService } from '@/services/@factories/barber-user/make-delete-user'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const DeleteBarberUserController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeDeleteUserService()
-    await service.execute({ id })
-    return reply.status(204).send()
-  },
-)
+export const DeleteBarberUserController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeDeleteUserService()
+  await service.execute({ id })
+  return reply.status(204).send()
+}

--- a/src/http/controllers/barber-user/get-user-controller.ts
+++ b/src/http/controllers/barber-user/get-user-controller.ts
@@ -1,20 +1,20 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeGetUserService } from '@/services/@factories/barber-user/make-get-user'
 import { makeBarberBalance } from '@/services/@factories/report/make-barber-balance'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetBarberUserController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeGetUserService()
-    const { user } = await service.execute({ id })
-    if (!user) return reply.status(404).send({ message: 'User not found' })
+export const GetBarberUserController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeGetUserService()
+  const { user } = await service.execute({ id })
+  if (!user) return reply.status(404).send({ message: 'User not found' })
 
-    const balanceService = makeBarberBalance()
-    const { balance } = await balanceService.execute({ barberId: id })
+  const balanceService = makeBarberBalance()
+  const { balance } = await balanceService.execute({ barberId: id })
 
-    return reply.status(200).send({ ...user, balance })
-  },
-)
+  return reply.status(200).send({ ...user, balance })
+}

--- a/src/http/controllers/barber-user/list-users-controller.ts
+++ b/src/http/controllers/barber-user/list-users-controller.ts
@@ -1,22 +1,22 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListUsersService } from '@/services/@factories/barber-user/make-list-users'
 import { makeBarberBalance } from '@/services/@factories/report/make-barber-balance'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListBarberUsersController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListUsersService()
-    const user = request.user as UserToken
-    const { users } = await service.execute(user)
-    const balanceService = makeBarberBalance()
-    const usersWithBalance = await Promise.all(
-      users.map(async (user) => {
-        const { balance } = await balanceService.execute({ barberId: user.id })
-        return { ...user, balance }
-      }),
-    )
+export const ListBarberUsersController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListUsersService()
+  const user = request.user as UserToken
+  const { users } = await service.execute(user)
+  const balanceService = makeBarberBalance()
+  const usersWithBalance = await Promise.all(
+    users.map(async (user) => {
+      const { balance } = await balanceService.execute({ barberId: user.id })
+      return { ...user, balance }
+    }),
+  )
 
-    return reply.status(200).send(usersWithBalance)
-  },
-)
+  return reply.status(200).send(usersWithBalance)
+}

--- a/src/http/controllers/barber-user/update-user-controller.ts
+++ b/src/http/controllers/barber-user/update-user-controller.ts
@@ -1,54 +1,54 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeUpdateUserService } from '@/services/@factories/barber-user/make-update-user'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { Role } from '@prisma/client'
 import { z } from 'zod'
 
-export const UpdateBarberUserController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const bodySchema = z.object({
-      name: z.string().optional(),
-      phone: z.string().optional(),
-      cpf: z.string().optional(),
-      genre: z.string().optional(),
-      birthday: z.string().optional(),
-      pix: z.string().optional(),
-      role: z.nativeEnum(Role).optional(),
-      unitId: z.string().optional(),
-      commissionPercentage: z.number().optional(),
-      active: z
-        .union([z.boolean(), z.string()])
-        .transform((val) => {
-          if (typeof val === 'boolean') return val
-          return val === 'true'
-        })
-        .optional(),
-    })
+export const UpdateBarberUserController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const bodySchema = z.object({
+    name: z.string().optional(),
+    phone: z.string().optional(),
+    cpf: z.string().optional(),
+    genre: z.string().optional(),
+    birthday: z.string().optional(),
+    pix: z.string().optional(),
+    role: z.nativeEnum(Role).optional(),
+    unitId: z.string().optional(),
+    commissionPercentage: z.number().optional(),
+    active: z
+      .union([z.boolean(), z.string()])
+      .transform((val) => {
+        if (typeof val === 'boolean') return val
+        return val === 'true'
+      })
+      .optional(),
+  })
 
-    const { id } = paramsSchema.parse(request.params)
-    const data = bodySchema.parse(request.body)
-    const service = makeUpdateUserService()
-    const userToken = request.user as {
-      sub: string
-      organizationId: string
-      unitId: string
-      role: Role
-    }
-    const result = await service.execute({ id, ...data })
+  const { id } = paramsSchema.parse(request.params)
+  const data = bodySchema.parse(request.body)
+  const service = makeUpdateUserService()
+  const userToken = request.user as {
+    sub: string
+    organizationId: string
+    unitId: string
+    role: Role
+  }
+  const result = await service.execute({ id, ...data })
 
-    if (id === userToken.sub && (data.unitId || data.role)) {
-      const token = await reply.jwtSign(
-        {
-          unitId: result.user.unitId,
-          organizationId: result.user.organizationId,
-          role: result.profile?.role ?? userToken.role,
-        },
-        { sign: { sub: result.user.id } },
-      )
-      return reply.status(200).send({ ...result, token })
-    }
+  if (id === userToken.sub && (data.unitId || data.role)) {
+    const token = await reply.jwtSign(
+      {
+        unitId: result.user.unitId,
+        organizationId: result.user.organizationId,
+        role: result.profile?.role ?? userToken.role,
+      },
+      { sign: { sub: result.user.id } },
+    )
+    return reply.status(200).send({ ...result, token })
+  }
 
-    return reply.status(200).send(result)
-  },
-)
+  return reply.status(200).send(result)
+}

--- a/src/http/controllers/cash-register/close-session-controller.ts
+++ b/src/http/controllers/cash-register/close-session-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCloseSessionService } from '@/services/@factories/cash-register/make-close-session'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const CloseSessionController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeCloseSessionService()
-    const unitId = (request.user as UserToken).unitId
-    const { session } = await service.execute({ unitId })
-    return reply.status(200).send(session)
-  },
-)
+export const CloseSessionController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeCloseSessionService()
+  const unitId = (request.user as UserToken).unitId
+  const { session } = await service.execute({ unitId })
+  return reply.status(200).send(session)
+}

--- a/src/http/controllers/cash-register/list-sessions-controller.ts
+++ b/src/http/controllers/cash-register/list-sessions-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListSessionsService } from '@/services/@factories/cash-register/make-list-sessions'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListSessionsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListSessionsService()
-    const user = request.user as UserToken
-    const { sessions } = await service.execute(user)
-    return reply.status(200).send(sessions)
-  },
-)
+export const ListSessionsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListSessionsService()
+  const user = request.user as UserToken
+  const { sessions } = await service.execute(user)
+  return reply.status(200).send(sessions)
+}

--- a/src/http/controllers/cash-register/open-session-controller.ts
+++ b/src/http/controllers/cash-register/open-session-controller.ts
@@ -1,18 +1,18 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeOpenSessionService } from '@/services/@factories/cash-register/make-open-session'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const OpenSessionController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      initialAmount: z.number(),
-    })
-    const { initialAmount } = bodySchema.parse(request.body)
-    const service = makeOpenSessionService()
-    const user = request.user as UserToken
-    const { session } = await service.execute({ user, initialAmount })
-    return reply.status(201).send(session)
-  },
-)
+export const OpenSessionController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    initialAmount: z.number(),
+  })
+  const { initialAmount } = bodySchema.parse(request.body)
+  const service = makeOpenSessionService()
+  const user = request.user as UserToken
+  const { session } = await service.execute({ user, initialAmount })
+  return reply.status(201).send(session)
+}

--- a/src/http/controllers/config/export-users-controller.ts
+++ b/src/http/controllers/config/export-users-controller.ts
@@ -1,11 +1,11 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeExportUsers } from '@/services/@factories/config/make-export-users'
 import { FastifyReply, FastifyRequest } from 'fastify'
 
-export const ExportUsersController = withErrorHandling(
-  async (_: FastifyRequest, reply: FastifyReply) => {
-    const service = makeExportUsers()
-    const { users } = await service.execute()
-    return reply.status(200).send(users)
-  },
-)
+export const ExportUsersController = async (
+  _: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeExportUsers()
+  const { users } = await service.execute()
+  return reply.status(200).send(users)
+}

--- a/src/http/controllers/coupon/create-coupon-controller.ts
+++ b/src/http/controllers/coupon/create-coupon-controller.ts
@@ -1,31 +1,31 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateCouponService } from '@/services/@factories/coupon/make-create-coupon'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateCouponController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      code: z.string(),
-      description: z.string().optional(),
-      discount: z.number(),
-      discountType: z.enum(['PERCENTAGE', 'VALUE']).default('PERCENTAGE'),
-      imageUrl: z.string().optional(),
-      quantity: z.number().optional(),
-    })
-    const data = bodySchema.parse(request.body)
-    const service = makeCreateCouponService()
-    const unitId = (request.user as UserToken).unitId
-    const { coupon } = await service.execute({
-      code: data.code,
-      description: data.description,
-      discount: data.discount,
-      discountType: data.discountType,
-      imageUrl: data.imageUrl,
-      quantity: data.quantity,
-      unitId,
-    })
-    return reply.status(201).send(coupon)
-  },
-)
+export const CreateCouponController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    code: z.string(),
+    description: z.string().optional(),
+    discount: z.number(),
+    discountType: z.enum(['PERCENTAGE', 'VALUE']).default('PERCENTAGE'),
+    imageUrl: z.string().optional(),
+    quantity: z.number().optional(),
+  })
+  const data = bodySchema.parse(request.body)
+  const service = makeCreateCouponService()
+  const unitId = (request.user as UserToken).unitId
+  const { coupon } = await service.execute({
+    code: data.code,
+    description: data.description,
+    discount: data.discount,
+    discountType: data.discountType,
+    imageUrl: data.imageUrl,
+    quantity: data.quantity,
+    unitId,
+  })
+  return reply.status(201).send(coupon)
+}

--- a/src/http/controllers/coupon/delete-coupon-controller.ts
+++ b/src/http/controllers/coupon/delete-coupon-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeDeleteCouponService } from '@/services/@factories/coupon/make-delete-coupon'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const DeleteCouponController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeDeleteCouponService()
-    await service.execute({ id })
-    return reply.status(204).send()
-  },
-)
+export const DeleteCouponController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeDeleteCouponService()
+  await service.execute({ id })
+  return reply.status(204).send()
+}

--- a/src/http/controllers/coupon/get-coupon-controller.ts
+++ b/src/http/controllers/coupon/get-coupon-controller.ts
@@ -1,15 +1,15 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeGetCouponService } from '@/services/@factories/coupon/make-get-coupon'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetCouponController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeGetCouponService()
-    const { coupon } = await service.execute({ id })
-    if (!coupon) return reply.status(404).send({ message: 'Coupon not found' })
-    return reply.status(200).send(coupon)
-  },
-)
+export const GetCouponController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeGetCouponService()
+  const { coupon } = await service.execute({ id })
+  if (!coupon) return reply.status(404).send({ message: 'Coupon not found' })
+  return reply.status(200).send(coupon)
+}

--- a/src/http/controllers/coupon/list-coupons-controller.ts
+++ b/src/http/controllers/coupon/list-coupons-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListCouponsService } from '@/services/@factories/coupon/make-list-coupons'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListCouponsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListCouponsService()
-    const user = request.user as UserToken
-    const { coupons } = await service.execute(user)
-    return reply.status(200).send(coupons)
-  },
-)
+export const ListCouponsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListCouponsService()
+  const user = request.user as UserToken
+  const { coupons } = await service.execute(user)
+  return reply.status(200).send(coupons)
+}

--- a/src/http/controllers/coupon/update-coupon-controller.ts
+++ b/src/http/controllers/coupon/update-coupon-controller.ts
@@ -1,16 +1,16 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeUpdateCouponService } from '@/services/@factories/coupon/make-update-coupon'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const UpdateCouponController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const bodySchema = z.object({ quantity: z.number() })
-    const { id } = paramsSchema.parse(request.params)
-    const { quantity } = bodySchema.parse(request.body)
-    const service = makeUpdateCouponService()
-    const { coupon } = await service.execute({ id, data: { quantity } })
-    return reply.status(200).send(coupon)
-  },
-)
+export const UpdateCouponController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const bodySchema = z.object({ quantity: z.number() })
+  const { id } = paramsSchema.parse(request.params)
+  const { quantity } = bodySchema.parse(request.body)
+  const service = makeUpdateCouponService()
+  const { coupon } = await service.execute({ id, data: { quantity } })
+  return reply.status(200).send(coupon)
+}

--- a/src/http/controllers/organization/create-organization-controller.ts
+++ b/src/http/controllers/organization/create-organization-controller.ts
@@ -1,17 +1,17 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateOrganizationService } from '@/services/@factories/organization/make-create-organization'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const CreateOrganizationController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string(),
-      slug: z.string(),
-    })
-    const { name, slug } = bodySchema.parse(request.body)
-    const service = makeCreateOrganizationService()
-    const { organization } = await service.execute({ name, slug })
-    return reply.status(201).send(organization)
-  },
-)
+export const CreateOrganizationController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string(),
+    slug: z.string(),
+  })
+  const { name, slug } = bodySchema.parse(request.body)
+  const service = makeCreateOrganizationService()
+  const { organization } = await service.execute({ name, slug })
+  return reply.status(201).send(organization)
+}

--- a/src/http/controllers/organization/delete-organization-controller.ts
+++ b/src/http/controllers/organization/delete-organization-controller.ts
@@ -1,16 +1,16 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeDeleteOrganizationService } from '@/services/@factories/organization/make-delete-organization'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const DeleteOrganizationController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({
-      id: z.string(),
-    })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeDeleteOrganizationService()
-    await service.execute(id)
-    return reply.status(204).send()
-  },
-)
+export const DeleteOrganizationController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({
+    id: z.string(),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeDeleteOrganizationService()
+  await service.execute(id)
+  return reply.status(204).send()
+}

--- a/src/http/controllers/organization/get-organization-controller.ts
+++ b/src/http/controllers/organization/get-organization-controller.ts
@@ -1,16 +1,16 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeGetOrganizationService } from '@/services/@factories/organization/make-get-organization'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetOrganizationController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({
-      id: z.string(),
-    })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeGetOrganizationService()
-    const { organization } = await service.execute(id)
-    return reply.status(200).send(organization)
-  },
-)
+export const GetOrganizationController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({
+    id: z.string(),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeGetOrganizationService()
+  const { organization } = await service.execute(id)
+  return reply.status(200).send(organization)
+}

--- a/src/http/controllers/organization/list-organizations-controller.ts
+++ b/src/http/controllers/organization/list-organizations-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListOrganizationsService } from '@/services/@factories/organization/make-list-organizations'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListOrganizationsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListOrganizationsService()
-    const user = request.user as UserToken
-    const { organizations } = await service.execute(user)
-    return reply.status(200).send(organizations)
-  },
-)
+export const ListOrganizationsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListOrganizationsService()
+  const user = request.user as UserToken
+  const { organizations } = await service.execute(user)
+  return reply.status(200).send(organizations)
+}

--- a/src/http/controllers/organization/update-organization-controller.ts
+++ b/src/http/controllers/organization/update-organization-controller.ts
@@ -1,21 +1,21 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeUpdateOrganizationService } from '@/services/@factories/organization/make-update-organization'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const UpdateOrganizationController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string(),
-      slug: z.string().optional(),
-    })
-    const paramsSchema = z.object({
-      id: z.string(),
-    })
-    const { name, slug } = bodySchema.parse(request.body)
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeUpdateOrganizationService()
-    const { organization } = await service.execute({ id, name, slug })
-    return reply.status(200).send(organization)
-  },
-)
+export const UpdateOrganizationController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string(),
+    slug: z.string().optional(),
+  })
+  const paramsSchema = z.object({
+    id: z.string(),
+  })
+  const { name, slug } = bodySchema.parse(request.body)
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeUpdateOrganizationService()
+  const { organization } = await service.execute({ id, name, slug })
+  return reply.status(200).send(organization)
+}

--- a/src/http/controllers/password/reset-with-token-controller.ts
+++ b/src/http/controllers/password/reset-with-token-controller.ts
@@ -1,20 +1,20 @@
 import { makeResetPasswordWithTokenService } from '@/services/@factories/user/make-reset-password-with-token'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
-export const ResetWithTokenController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      token: z.string(),
-      password: z.string().min(6),
-    })
+export const ResetWithTokenController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    token: z.string(),
+    password: z.string().min(6),
+  })
 
-    const { token, password } = bodySchema.parse(request.body)
+  const { token, password } = bodySchema.parse(request.body)
 
-    const service = makeResetPasswordWithTokenService()
-    await service.execute({ token, password })
+  const service = makeResetPasswordWithTokenService()
+  await service.execute({ token, password })
 
-    return reply.status(200).send()
-  },
-)
+  return reply.status(200).send()
+}

--- a/src/http/controllers/password/send-reset-link-controller.ts
+++ b/src/http/controllers/password/send-reset-link-controller.ts
@@ -1,18 +1,18 @@
 import { makeRequestPasswordResetService } from '@/services/@factories/user/make-request-password-reset'
 import { FastifyRequest, FastifyReply } from 'fastify'
 import { z } from 'zod'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
-export const SendResetLinkController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      email: z.string().email(),
-    })
-    const { email } = bodySchema.parse(request.body)
+export const SendResetLinkController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    email: z.string().email(),
+  })
+  const { email } = bodySchema.parse(request.body)
 
-    const service = makeRequestPasswordResetService()
-    await service.execute({ email })
+  const service = makeRequestPasswordResetService()
+  await service.execute({ email })
 
-    return reply.status(200).send()
-  },
-)
+  return reply.status(200).send()
+}

--- a/src/http/controllers/product/create-product-controller.ts
+++ b/src/http/controllers/product/create-product-controller.ts
@@ -1,36 +1,36 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateProductService } from '@/services/@factories/product/make-create-product'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateProductController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string(),
-      description: z.string().optional(),
-      quantity: z.coerce.number().optional(),
-      cost: z.coerce.number(),
-      price: z.coerce.number(),
-    })
-    const data = bodySchema.parse(request.body)
+export const CreateProductController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    quantity: z.coerce.number().optional(),
+    cost: z.coerce.number(),
+    price: z.coerce.number(),
+  })
+  const data = bodySchema.parse(request.body)
 
-    const imageUrl = request.file
-      ? `/uploads/${request.file.filename}`
-      : undefined
+  const imageUrl = request.file
+    ? `/uploads/${request.file.filename}`
+    : undefined
 
-    const service = makeCreateProductService()
-    const unitId = (request.user as UserToken).unitId
-    const { product } = await service.execute({
-      name: data.name,
-      description: data.description,
-      quantity: data.quantity,
-      cost: data.cost,
-      price: data.price,
-      imageUrl,
-      unitId,
-    })
+  const service = makeCreateProductService()
+  const unitId = (request.user as UserToken).unitId
+  const { product } = await service.execute({
+    name: data.name,
+    description: data.description,
+    quantity: data.quantity,
+    cost: data.cost,
+    price: data.price,
+    imageUrl,
+    unitId,
+  })
 
-    return reply.status(201).send(product)
-  },
-)
+  return reply.status(201).send(product)
+}

--- a/src/http/controllers/product/delete-product-controller.ts
+++ b/src/http/controllers/product/delete-product-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeDeleteProductService } from '@/services/@factories/product/make-delete-product'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const DeleteProductController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeDeleteProductService()
-    await service.execute({ id })
-    return reply.status(204).send()
-  },
-)
+export const DeleteProductController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeDeleteProductService()
+  await service.execute({ id })
+  return reply.status(204).send()
+}

--- a/src/http/controllers/product/get-product-controller.ts
+++ b/src/http/controllers/product/get-product-controller.ts
@@ -1,16 +1,15 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeGetProductService } from '@/services/@factories/product/make-get-product'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetProductController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeGetProductService()
-    const { product } = await service.execute({ id })
-    if (!product)
-      return reply.status(404).send({ message: 'Product not found' })
-    return reply.status(200).send(product)
-  },
-)
+export const GetProductController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeGetProductService()
+  const { product } = await service.execute({ id })
+  if (!product) return reply.status(404).send({ message: 'Product not found' })
+  return reply.status(200).send(product)
+}

--- a/src/http/controllers/product/list-products-controller.ts
+++ b/src/http/controllers/product/list-products-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListProductsService } from '@/services/@factories/product/make-list-products'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListProductsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListProductsService()
-    const userToken = request.user as UserToken
-    const { products } = await service.execute(userToken)
-    return reply.status(200).send(products)
-  },
-)
+export const ListProductsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListProductsService()
+  const userToken = request.user as UserToken
+  const { products } = await service.execute(userToken)
+  return reply.status(200).send(products)
+}

--- a/src/http/controllers/product/update-product-controller.ts
+++ b/src/http/controllers/product/update-product-controller.ts
@@ -1,23 +1,23 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeUpdateProductService } from '@/services/@factories/product/make-update-product'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const UpdateProductController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const bodySchema = z.object({
-      name: z.string().optional(),
-      description: z.string().optional(),
-      quantity: z.number().optional(),
-      cost: z.number().optional(),
-      price: z.number().optional(),
-      imageUrl: z.string().optional(),
-    })
-    const { id } = paramsSchema.parse(request.params)
-    const data = bodySchema.parse(request.body)
-    const service = makeUpdateProductService()
-    const { product } = await service.execute({ id, data })
-    return reply.status(200).send(product)
-  },
-)
+export const UpdateProductController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const bodySchema = z.object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    quantity: z.number().optional(),
+    cost: z.number().optional(),
+    price: z.number().optional(),
+    imageUrl: z.string().optional(),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const data = bodySchema.parse(request.body)
+  const service = makeUpdateProductService()
+  const { product } = await service.execute({ id, data })
+  return reply.status(200).send(product)
+}

--- a/src/http/controllers/profile/create.ts
+++ b/src/http/controllers/profile/create.ts
@@ -1,5 +1,4 @@
 import { makeCreateProfileService } from '@/services/@factories/profile/make-create-profile-service'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
 import { Role } from '@prisma/client'
 import { FastifyReply, FastifyRequest } from 'fastify'
@@ -14,23 +13,21 @@ const bodySchema = z.object({
   role: z.nativeEnum(Role),
 })
 
-export const Create = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const body = bodySchema.parse(request.body)
+export const Create = async (request: FastifyRequest, reply: FastifyReply) => {
+  const body = bodySchema.parse(request.body)
 
-    const createProfileService = makeCreateProfileService()
+  const createProfileService = makeCreateProfileService()
 
-    const userId = request.user.sub
+  const userId = request.user.sub
 
-    const { profile } = await createProfileService.execute({
-      phone: body.phone,
-      cpf: body.cpf,
-      genre: body.genre,
-      birthday: body.birthday,
-      pix: body.pix,
-      role: body.role,
-      userId,
-    })
-    return reply.status(201).send(profile)
-  },
-)
+  const { profile } = await createProfileService.execute({
+    phone: body.phone,
+    cpf: body.cpf,
+    genre: body.genre,
+    birthday: body.birthday,
+    pix: body.pix,
+    role: body.role,
+    userId,
+  })
+  return reply.status(201).send(profile)
+}

--- a/src/http/controllers/profile/get-profile.ts
+++ b/src/http/controllers/profile/get-profile.ts
@@ -2,17 +2,17 @@ import { getProfileFromUserIdService } from '@/services/@factories/profile/get-p
 
 import { Role } from '@prisma/client'
 import { FastifyReply, FastifyRequest } from 'fastify'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
-export const GetProfile = withErrorHandling(
-  async (request: FastifyRequest, replay: FastifyReply) => {
-    const getProfileFromUserId = getProfileFromUserIdService()
-    const userId = request.user.sub
-    const { profile } = await getProfileFromUserId.execute({ id: userId })
+export const GetProfile = async (
+  request: FastifyRequest,
+  replay: FastifyReply,
+) => {
+  const getProfileFromUserId = getProfileFromUserIdService()
+  const userId = request.user.sub
+  const { profile } = await getProfileFromUserId.execute({ id: userId })
 
-    return replay.status(200).send({
-      profile,
-      roles: Role,
-    })
-  },
-)
+  return replay.status(200).send({
+    profile,
+    roles: Role,
+  })
+}

--- a/src/http/controllers/profile/update.ts
+++ b/src/http/controllers/profile/update.ts
@@ -3,7 +3,6 @@ import { getProfileFromUserIdService } from '@/services/@factories/profile/get-p
 import { MakeUpdateProfileUserService } from '@/services/@factories/profile/update-profile-user-service'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
 const bodySchema = z.object({
   name: z.string(),
@@ -16,36 +15,34 @@ const bodySchema = z.object({
   pix: z.string(),
 })
 
-export const Update = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const { active, birthday, cpf, email, genre, name, phone, pix } =
-      bodySchema.parse(request.body)
+export const Update = async (request: FastifyRequest, reply: FastifyReply) => {
+  const { active, birthday, cpf, email, genre, name, phone, pix } =
+    bodySchema.parse(request.body)
 
-    const updateProfileUserService = MakeUpdateProfileUserService()
-    const getProfileFromUserId = getProfileFromUserIdService()
+  const updateProfileUserService = MakeUpdateProfileUserService()
+  const getProfileFromUserId = getProfileFromUserIdService()
 
-    const id = request.user.sub
+  const id = request.user.sub
 
-    const { profile } = await getProfileFromUserId.execute({
-      id,
-    })
+  const { profile } = await getProfileFromUserId.execute({
+    id,
+  })
 
-    if (!profile) {
-      throw new ResourceNotFoundError()
-    }
+  if (!profile) {
+    throw new ResourceNotFoundError()
+  }
 
-    const { profile: profileUpdate } = await updateProfileUserService.execute({
-      active,
-      birthday,
-      cpf,
-      email,
-      genre,
-      id,
-      name,
-      phone,
-      pix,
-      role: profile.role,
-    })
-    return reply.status(201).send({ profile: profileUpdate })
-  },
-)
+  const { profile: profileUpdate } = await updateProfileUserService.execute({
+    active,
+    birthday,
+    cpf,
+    email,
+    genre,
+    id,
+    name,
+    phone,
+    pix,
+    role: profile.role,
+  })
+  return reply.status(201).send({ profile: profileUpdate })
+}

--- a/src/http/controllers/profile/updateWithId.ts
+++ b/src/http/controllers/profile/updateWithId.ts
@@ -2,7 +2,6 @@ import { MakeUpdateProfileUserService } from '@/services/@factories/profile/upda
 import { Role } from '@prisma/client'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
 const bodySchema = z.object({
   name: z.string(),
@@ -20,27 +19,28 @@ const routeSchema = z.object({
   id: z.string(),
 })
 
-export const UpdateWithId = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const { active, birthday, cpf, email, genre, name, phone, pix, role } =
-      bodySchema.parse(request.body)
+export const UpdateWithId = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const { active, birthday, cpf, email, genre, name, phone, pix, role } =
+    bodySchema.parse(request.body)
 
-    const updateProfileUserService = MakeUpdateProfileUserService()
+  const updateProfileUserService = MakeUpdateProfileUserService()
 
-    const { id } = routeSchema.parse(request.params)
+  const { id } = routeSchema.parse(request.params)
 
-    const { profile } = await updateProfileUserService.execute({
-      active,
-      birthday,
-      cpf,
-      email,
-      genre,
-      id,
-      name,
-      phone,
-      pix,
-      role,
-    })
-    return reply.status(201).send({ profile })
-  },
-)
+  const { profile } = await updateProfileUserService.execute({
+    active,
+    birthday,
+    cpf,
+    email,
+    genre,
+    id,
+    name,
+    phone,
+    pix,
+    role,
+  })
+  return reply.status(201).send({ profile })
+}

--- a/src/http/controllers/register-user-controller.ts
+++ b/src/http/controllers/register-user-controller.ts
@@ -2,44 +2,44 @@ import { makeRegisterService } from '@/services/@factories/make-register-service
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { Role } from '@prisma/client'
 import { z } from 'zod'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
-export const registerUser = withErrorHandling(
-  async (request: FastifyRequest, replay: FastifyReply) => {
-    const registerBodySchema = z.object({
-      name: z.string(),
-      email: z.string().email(),
-      password: z.string().min(6),
-      phone: z.string(),
-      cpf: z.string(),
-      genre: z.string(),
-      birthday: z.string(),
-      pix: z.string(),
-      role: z.nativeEnum(Role),
-      unitId: z.string(),
-    })
+export const registerUser = async (
+  request: FastifyRequest,
+  replay: FastifyReply,
+) => {
+  const registerBodySchema = z.object({
+    name: z.string(),
+    email: z.string().email(),
+    password: z.string().min(6),
+    phone: z.string(),
+    cpf: z.string(),
+    genre: z.string(),
+    birthday: z.string(),
+    pix: z.string(),
+    role: z.nativeEnum(Role),
+    unitId: z.string(),
+  })
 
-    const data = registerBodySchema.parse(request.body)
+  const data = registerBodySchema.parse(request.body)
 
-    if (data.role === 'ADMIN' || data.role === 'OWNER') {
-      return replay.status(403).send({ message: 'Unauthorized role' })
-    }
+  if (data.role === 'ADMIN' || data.role === 'OWNER') {
+    return replay.status(403).send({ message: 'Unauthorized role' })
+  }
 
-    const registerService = makeRegisterService()
+  const registerService = makeRegisterService()
 
-    await registerService.execute({
-      name: data.name,
-      email: data.email,
-      password: data.password,
-      phone: data.phone,
-      cpf: data.cpf,
-      genre: data.genre,
-      birthday: data.birthday,
-      pix: data.pix,
-      role: data.role,
-      unitId: data.unitId,
-    })
+  await registerService.execute({
+    name: data.name,
+    email: data.email,
+    password: data.password,
+    phone: data.phone,
+    cpf: data.cpf,
+    genre: data.genre,
+    birthday: data.birthday,
+    pix: data.pix,
+    role: data.role,
+    unitId: data.unitId,
+  })
 
-    return replay.status(201).send()
-  },
-)
+  return replay.status(201).send()
+}

--- a/src/http/controllers/report/get-barber-balance-controller.ts
+++ b/src/http/controllers/report/get-barber-balance-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeBarberBalance } from '@/services/@factories/report/make-barber-balance'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetBarberBalanceController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ barberId: z.string() })
-    const { barberId } = paramsSchema.parse(request.params)
-    const service = makeBarberBalance()
-    const { balance, historySales } = await service.execute({ barberId })
-    return reply.status(200).send({ balance, historySales })
-  },
-)
+export const GetBarberBalanceController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ barberId: z.string() })
+  const { barberId } = paramsSchema.parse(request.params)
+  const service = makeBarberBalance()
+  const { balance, historySales } = await service.execute({ barberId })
+  return reply.status(200).send({ balance, historySales })
+}

--- a/src/http/controllers/report/get-cash-session-report-controller.ts
+++ b/src/http/controllers/report/get-cash-session-report-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCashSessionReport } from '@/services/@factories/report/make-cash-session-report'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetCashSessionReportController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ sessionId: z.string() })
-    const { sessionId } = paramsSchema.parse(request.params)
-    const service = makeCashSessionReport()
-    const report = await service.execute({ sessionId })
-    return reply.status(200).send(report)
-  },
-)
+export const GetCashSessionReportController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ sessionId: z.string() })
+  const { sessionId } = paramsSchema.parse(request.params)
+  const service = makeCashSessionReport()
+  const report = await service.execute({ sessionId })
+  return reply.status(200).send(report)
+}

--- a/src/http/controllers/report/get-owner-balance-controller.ts
+++ b/src/http/controllers/report/get-owner-balance-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeOwnerBalance } from '@/services/@factories/report/make-owner-balance'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetOwnerBalanceController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ ownerId: z.string() })
-    const { ownerId } = paramsSchema.parse(request.params)
-    const service = makeOwnerBalance()
-    const { balance, historySales } = await service.execute({ ownerId })
-    return reply.status(200).send({ balance, historySales })
-  },
-)
+export const GetOwnerBalanceController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ ownerId: z.string() })
+  const { ownerId } = paramsSchema.parse(request.params)
+  const service = makeOwnerBalance()
+  const { balance, historySales } = await service.execute({ ownerId })
+  return reply.status(200).send({ balance, historySales })
+}

--- a/src/http/controllers/report/get-sales-report-controller.ts
+++ b/src/http/controllers/report/get-sales-report-controller.ts
@@ -1,17 +1,17 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeSalesReport } from '@/services/@factories/report/make-sales-report'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetSalesReportController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const querySchema = z.object({
-      startDate: z.coerce.date(),
-      endDate: z.coerce.date(),
-    })
-    const { startDate, endDate } = querySchema.parse(request.query)
-    const service = makeSalesReport()
-    const report = await service.execute({ startDate, endDate })
-    return reply.status(200).send(report)
-  },
-)
+export const GetSalesReportController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const querySchema = z.object({
+    startDate: z.coerce.date(),
+    endDate: z.coerce.date(),
+  })
+  const { startDate, endDate } = querySchema.parse(request.query)
+  const service = makeSalesReport()
+  const report = await service.execute({ startDate, endDate })
+  return reply.status(200).send(report)
+}

--- a/src/http/controllers/report/get-unit-loan-balance-controller.ts
+++ b/src/http/controllers/report/get-unit-loan-balance-controller.ts
@@ -1,14 +1,14 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeUnitLoanBalance } from '@/services/@factories/report/make-unit-loan-balance'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetUnitLoanBalanceController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ unitId: z.string() })
-    const { unitId } = paramsSchema.parse(request.params)
-    const service = makeUnitLoanBalance()
-    const { borrowed, paid } = await service.execute({ unitId })
-    return reply.status(200).send({ borrowed, paid })
-  },
-)
+export const GetUnitLoanBalanceController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ unitId: z.string() })
+  const { unitId } = paramsSchema.parse(request.params)
+  const service = makeUnitLoanBalance()
+  const { borrowed, paid } = await service.execute({ unitId })
+  return reply.status(200).send({ borrowed, paid })
+}

--- a/src/http/controllers/sale/create-sale-controller.ts
+++ b/src/http/controllers/sale/create-sale-controller.ts
@@ -1,37 +1,37 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateSale } from '@/services/@factories/sale/make-create-sale'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const CreateSaleController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      method: z.enum(['CASH', 'PIX', 'CREDIT_CARD', 'DEBIT_CARD']),
-      items: z.array(
-        z.object({
-          serviceId: z.string().optional(),
-          productId: z.string().optional(),
-          quantity: z.number().min(1),
-          barberId: z.string().optional(),
-          couponCode: z.string().optional(),
-          price: z.number().optional(),
-        }),
-      ),
-      clientId: z.string(),
-      couponCode: z.string().optional(),
-      paymentStatus: z.enum(['PAID', 'PENDING']).optional().default('PENDING'),
-    })
-    const data = bodySchema.parse(request.body)
-    const userId = request.user.sub
-    const service = makeCreateSale()
-    const { sale } = await service.execute({
-      method: data.method,
-      items: data.items,
-      clientId: data.clientId,
-      couponCode: data.couponCode,
-      paymentStatus: data.paymentStatus,
-      userId,
-    })
-    return reply.status(201).send(sale)
-  },
-)
+export const CreateSaleController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    method: z.enum(['CASH', 'PIX', 'CREDIT_CARD', 'DEBIT_CARD']),
+    items: z.array(
+      z.object({
+        serviceId: z.string().optional(),
+        productId: z.string().optional(),
+        quantity: z.number().min(1),
+        barberId: z.string().optional(),
+        couponCode: z.string().optional(),
+        price: z.number().optional(),
+      }),
+    ),
+    clientId: z.string(),
+    couponCode: z.string().optional(),
+    paymentStatus: z.enum(['PAID', 'PENDING']).optional().default('PENDING'),
+  })
+  const data = bodySchema.parse(request.body)
+  const userId = request.user.sub
+  const service = makeCreateSale()
+  const { sale } = await service.execute({
+    method: data.method,
+    items: data.items,
+    clientId: data.clientId,
+    couponCode: data.couponCode,
+    paymentStatus: data.paymentStatus,
+    userId,
+  })
+  return reply.status(201).send(sale)
+}

--- a/src/http/controllers/sale/get-sale-controller.ts
+++ b/src/http/controllers/sale/get-sale-controller.ts
@@ -1,15 +1,15 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeGetSale } from '@/services/@factories/sale/make-get-sale'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetSaleController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeGetSale()
-    const { sale } = await service.execute({ id })
-    if (!sale) return reply.status(404).send({ message: 'Sale not found' })
-    return reply.status(200).send(sale)
-  },
-)
+export const GetSaleController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeGetSale()
+  const { sale } = await service.execute({ id })
+  if (!sale) return reply.status(404).send({ message: 'Sale not found' })
+  return reply.status(200).send(sale)
+}

--- a/src/http/controllers/sale/list-sales-controller.ts
+++ b/src/http/controllers/sale/list-sales-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListSales } from '@/services/@factories/sale/make-list-sales'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListSalesController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListSales()
-    const user = request.user as UserToken
-    const { sales } = await service.execute(user)
-    return reply.status(200).send(sales)
-  },
-)
+export const ListSalesController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListSales()
+  const user = request.user as UserToken
+  const { sales } = await service.execute(user)
+  return reply.status(200).send(sales)
+}

--- a/src/http/controllers/sale/set-sale-status-controller.ts
+++ b/src/http/controllers/sale/set-sale-status-controller.ts
@@ -1,23 +1,23 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeSetSaleStatus } from '@/services/@factories/sale/make-set-sale-status'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const SetSaleStatusController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({ id: z.string() })
-    const bodySchema = z.object({
-      paymentStatus: z.enum(['PAID', 'PENDING']),
-    })
-    const { id } = paramsSchema.parse(request.params)
-    const { paymentStatus } = bodySchema.parse(request.body)
-    const userId = request.user.sub
-    const service = makeSetSaleStatus()
-    const { sale } = await service.execute({
-      saleId: id,
-      userId,
-      paymentStatus,
-    })
-    return reply.status(200).send(sale)
-  },
-)
+export const SetSaleStatusController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({ id: z.string() })
+  const bodySchema = z.object({
+    paymentStatus: z.enum(['PAID', 'PENDING']),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const { paymentStatus } = bodySchema.parse(request.body)
+  const userId = request.user.sub
+  const service = makeSetSaleStatus()
+  const { sale } = await service.execute({
+    saleId: id,
+    userId,
+    paymentStatus,
+  })
+  return reply.status(200).send(sale)
+}

--- a/src/http/controllers/set-user-unit-controller.ts
+++ b/src/http/controllers/set-user-unit-controller.ts
@@ -2,22 +2,22 @@ import { makeSetUserUnitService } from '@/services/@factories/user/make-set-user
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from './authenticate-controller'
-import { withErrorHandling } from '@/utils/http-error-handler'
 
-export const SetUserUnitController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({ unitId: z.string() })
-    const { unitId } = bodySchema.parse(request.body)
-    const user = request.user as UserToken
+export const SetUserUnitController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({ unitId: z.string() })
+  const { unitId } = bodySchema.parse(request.body)
+  const user = request.user as UserToken
 
-    const service = makeSetUserUnitService()
-    await service.execute({ user, unitId })
+  const service = makeSetUserUnitService()
+  await service.execute({ user, unitId })
 
-    const token = await reply.jwtSign(
-      { unitId, organizationId: user.organizationId, role: user.role },
-      { sign: { sub: user.sub } },
-    )
+  const token = await reply.jwtSign(
+    { unitId, organizationId: user.organizationId, role: user.role },
+    { sign: { sub: user.sub } },
+  )
 
-    return reply.status(200).send({ token })
-  },
-)
+  return reply.status(200).send({ token })
+}

--- a/src/http/controllers/transaction/add-balance-transaction.ts
+++ b/src/http/controllers/transaction/add-balance-transaction.ts
@@ -1,37 +1,37 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 import { makeAddBalanceTransaction } from '@/services/@factories/transaction/make-add-balance-transaction'
 import { assertPermission } from '@/utils/permissions'
 
-export const AddBalanceTransactionController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      description: z.string(),
-      amount: z.coerce.number(),
-      affectedUserId: z.string().optional(),
-    })
-    const user = request.user as UserToken
-    const data = bodySchema.parse(request.body)
+export const AddBalanceTransactionController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    description: z.string(),
+    amount: z.coerce.number(),
+    affectedUserId: z.string().optional(),
+  })
+  const user = request.user as UserToken
+  const data = bodySchema.parse(request.body)
 
-    if (data.affectedUserId) {
-      assertPermission(user.role, 'MANAGE_OTHER_USER_TRANSACTION')
-    }
+  if (data.affectedUserId) {
+    assertPermission(user.role, 'MANAGE_OTHER_USER_TRANSACTION')
+  }
 
-    const receiptUrl = request.file
-      ? `/uploads/${request.file.filename}`
-      : undefined
+  const receiptUrl = request.file
+    ? `/uploads/${request.file.filename}`
+    : undefined
 
-    const userId = user.sub
-    const service = makeAddBalanceTransaction()
-    const { transactions, surplusValue } = await service.execute({
-      description: data.description,
-      amount: data.amount,
-      userId,
-      affectedUserId: data.affectedUserId,
-      receiptUrl,
-    })
-    return reply.status(201).send({ transactions, surplusValue })
-  },
-)
+  const userId = user.sub
+  const service = makeAddBalanceTransaction()
+  const { transactions, surplusValue } = await service.execute({
+    description: data.description,
+    amount: data.amount,
+    userId,
+    affectedUserId: data.affectedUserId,
+    receiptUrl,
+  })
+  return reply.status(201).send({ transactions, surplusValue })
+}

--- a/src/http/controllers/transaction/create-transaction-controller.ts
+++ b/src/http/controllers/transaction/create-transaction-controller.ts
@@ -1,32 +1,32 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateTransaction } from '@/services/@factories/transaction/make-create-transaction'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateTransactionController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      type: z.enum(['ADDITION', 'WITHDRAWAL']),
-      description: z.string(),
-      amount: z.coerce.number(),
-      affectedUserId: z.string().optional(),
-    })
-    const data = bodySchema.parse(request.body)
-    const receiptUrl = request.file
-      ? `/uploads/${request.file.filename}`
-      : undefined
-    const user = request.user as UserToken
-    const userId = user.sub
-    const service = makeCreateTransaction()
-    const { transaction } = await service.execute({
-      type: data.type,
-      description: data.description,
-      amount: data.amount,
-      userId,
-      affectedUserId: data.affectedUserId,
-      receiptUrl,
-    })
-    return reply.status(201).send({ transaction })
-  },
-)
+export const CreateTransactionController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    type: z.enum(['ADDITION', 'WITHDRAWAL']),
+    description: z.string(),
+    amount: z.coerce.number(),
+    affectedUserId: z.string().optional(),
+  })
+  const data = bodySchema.parse(request.body)
+  const receiptUrl = request.file
+    ? `/uploads/${request.file.filename}`
+    : undefined
+  const user = request.user as UserToken
+  const userId = user.sub
+  const service = makeCreateTransaction()
+  const { transaction } = await service.execute({
+    type: data.type,
+    description: data.description,
+    amount: data.amount,
+    userId,
+    affectedUserId: data.affectedUserId,
+    receiptUrl,
+  })
+  return reply.status(201).send({ transaction })
+}

--- a/src/http/controllers/transaction/list-transactions-controller.ts
+++ b/src/http/controllers/transaction/list-transactions-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListTransactions } from '@/services/@factories/transaction/make-list-transactions'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListTransactionsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListTransactions()
-    const user = request.user as UserToken
-    const { transactions } = await service.execute(user)
-    return reply.status(200).send(transactions)
-  },
-)
+export const ListTransactionsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListTransactions()
+  const user = request.user as UserToken
+  const { transactions } = await service.execute(user)
+  return reply.status(200).send(transactions)
+}

--- a/src/http/controllers/transaction/withdrawal-balance-transaction.ts
+++ b/src/http/controllers/transaction/withdrawal-balance-transaction.ts
@@ -1,36 +1,36 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 import { makeWithdrawalBalanceTransaction } from '@/services/@factories/transaction/make-withdrawal-balance-transaction'
 import { assertPermission } from '@/utils/permissions'
 
-export const WithdrawalBalanceTransactionController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      description: z.string(),
-      amount: z.coerce.number(),
-      affectedUserId: z.string().optional(),
-    })
-    const user = request.user as UserToken
-    const data = bodySchema.parse(request.body)
+export const WithdrawalBalanceTransactionController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    description: z.string(),
+    amount: z.coerce.number(),
+    affectedUserId: z.string().optional(),
+  })
+  const user = request.user as UserToken
+  const data = bodySchema.parse(request.body)
 
-    if (data.affectedUserId) {
-      assertPermission(user.role, 'MANAGE_OTHER_USER_TRANSACTION')
-    }
+  if (data.affectedUserId) {
+    assertPermission(user.role, 'MANAGE_OTHER_USER_TRANSACTION')
+  }
 
-    const receiptUrl = request.file
-      ? `/uploads/${request.file.filename}`
-      : undefined
-    const userId = user.sub
-    const service = makeWithdrawalBalanceTransaction()
-    const { transactions, surplusValue } = await service.execute({
-      description: data.description,
-      amount: data.amount,
-      userId,
-      affectedUserId: data.affectedUserId,
-      receiptUrl,
-    })
-    return reply.status(201).send({ transactions, surplusValue })
-  },
-)
+  const receiptUrl = request.file
+    ? `/uploads/${request.file.filename}`
+    : undefined
+  const userId = user.sub
+  const service = makeWithdrawalBalanceTransaction()
+  const { transactions, surplusValue } = await service.execute({
+    description: data.description,
+    amount: data.amount,
+    userId,
+    affectedUserId: data.affectedUserId,
+    receiptUrl,
+  })
+  return reply.status(201).send({ transactions, surplusValue })
+}

--- a/src/http/controllers/unit/create-unit-controller.ts
+++ b/src/http/controllers/unit/create-unit-controller.ts
@@ -1,27 +1,27 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeCreateUnitService } from '@/services/@factories/unit/make-create-unit'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 
-export const CreateUnitController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string(),
-      slug: z.string(),
-      organizationId: z.string().optional(),
-      allowsLoan: z.boolean().optional(),
-    })
-    const data = bodySchema.parse(request.body)
-    const service = makeCreateUnitService()
-    const userToken = request.user as UserToken
-    const { unit } = await service.execute({
-      name: data.name,
-      slug: data.slug,
-      organizationId: data.organizationId,
-      allowsLoan: data.allowsLoan,
-      userToken,
-    })
-    return reply.status(201).send(unit)
-  },
-)
+export const CreateUnitController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string(),
+    slug: z.string(),
+    organizationId: z.string().optional(),
+    allowsLoan: z.boolean().optional(),
+  })
+  const data = bodySchema.parse(request.body)
+  const service = makeCreateUnitService()
+  const userToken = request.user as UserToken
+  const { unit } = await service.execute({
+    name: data.name,
+    slug: data.slug,
+    organizationId: data.organizationId,
+    allowsLoan: data.allowsLoan,
+    userToken,
+  })
+  return reply.status(201).send(unit)
+}

--- a/src/http/controllers/unit/delete-unit-controller.ts
+++ b/src/http/controllers/unit/delete-unit-controller.ts
@@ -1,16 +1,16 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeDeleteUnitService } from '@/services/@factories/unit/make-delete-unit'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const DeleteUnitController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({
-      id: z.string(),
-    })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeDeleteUnitService()
-    await service.execute(id)
-    return reply.status(204).send()
-  },
-)
+export const DeleteUnitController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({
+    id: z.string(),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeDeleteUnitService()
+  await service.execute(id)
+  return reply.status(204).send()
+}

--- a/src/http/controllers/unit/get-unit-controller.ts
+++ b/src/http/controllers/unit/get-unit-controller.ts
@@ -1,16 +1,16 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeGetUnitService } from '@/services/@factories/unit/make-get-unit'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const GetUnitController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const paramsSchema = z.object({
-      id: z.string(),
-    })
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeGetUnitService()
-    const { unit } = await service.execute(id)
-    return reply.status(200).send(unit)
-  },
-)
+export const GetUnitController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const paramsSchema = z.object({
+    id: z.string(),
+  })
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeGetUnitService()
+  const { unit } = await service.execute(id)
+  return reply.status(200).send(unit)
+}

--- a/src/http/controllers/unit/list-units-controller.ts
+++ b/src/http/controllers/unit/list-units-controller.ts
@@ -1,13 +1,13 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeListUnitsService } from '@/services/@factories/unit/make-list-units'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
 
-export const ListUnitsController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const service = makeListUnitsService()
-    const user = request.user as UserToken
-    const { units } = await service.execute(user)
-    return reply.status(200).send(units)
-  },
-)
+export const ListUnitsController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const service = makeListUnitsService()
+  const user = request.user as UserToken
+  const { units } = await service.execute(user)
+  return reply.status(200).send(units)
+}

--- a/src/http/controllers/unit/update-unit-controller.ts
+++ b/src/http/controllers/unit/update-unit-controller.ts
@@ -1,28 +1,28 @@
-import { withErrorHandling } from '@/utils/http-error-handler'
 import { makeUpdateUnitService } from '@/services/@factories/unit/make-update-unit'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 
-export const UpdateUnitController = withErrorHandling(
-  async (request: FastifyRequest, reply: FastifyReply) => {
-    const bodySchema = z.object({
-      name: z.string().optional(),
-      slug: z.string().optional(),
-      allowsLoan: z
-        .union([z.boolean(), z.string()])
-        .transform((val) => {
-          if (typeof val === 'boolean') return val
-          return val === 'true'
-        })
-        .optional(),
-    })
-    const paramsSchema = z.object({
-      id: z.string(),
-    })
-    const { name, slug, allowsLoan } = bodySchema.parse(request.body)
-    const { id } = paramsSchema.parse(request.params)
-    const service = makeUpdateUnitService()
-    const { unit } = await service.execute({ id, name, slug, allowsLoan })
-    return reply.status(200).send(unit)
-  },
-)
+export const UpdateUnitController = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const bodySchema = z.object({
+    name: z.string().optional(),
+    slug: z.string().optional(),
+    allowsLoan: z
+      .union([z.boolean(), z.string()])
+      .transform((val) => {
+        if (typeof val === 'boolean') return val
+        return val === 'true'
+      })
+      .optional(),
+  })
+  const paramsSchema = z.object({
+    id: z.string(),
+  })
+  const { name, slug, allowsLoan } = bodySchema.parse(request.body)
+  const { id } = paramsSchema.parse(request.params)
+  const service = makeUpdateUnitService()
+  const { unit } = await service.execute({ id, name, slug, allowsLoan })
+  return reply.status(200).send(unit)
+}

--- a/src/utils/http-error-handler.ts
+++ b/src/utils/http-error-handler.ts
@@ -25,7 +25,7 @@ import { BarberNotFoundError } from '@/services/@errors/barber/barber-not-found-
 import { BarberProfileNotFoundError } from '@/services/@errors/profile/barber-profile-not-found-error'
 import { OwnerNotFoundError } from '@/services/@errors/organization/owner-not-found-error'
 import { UnitNotFromOrganizationError } from '@/services/users/set-user-unit'
-import { FastifyReply, FastifyRequest } from 'fastify'
+import { FastifyReply } from 'fastify'
 
 export function mapErrorToStatus(error: Error): number {
   if (
@@ -75,15 +75,4 @@ export function handleControllerError(error: unknown, reply: FastifyReply) {
     return reply.status(status).send({ message: error.message })
   }
   return reply.status(500).send({ message: 'Internal server error' })
-}
-export function withErrorHandling(
-  fn: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>,
-) {
-  return async (request: FastifyRequest, reply: FastifyReply) => {
-    try {
-      return await fn(request, reply)
-    } catch (error) {
-      return handleControllerError(error, reply)
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- remove `withErrorHandling` helper and rely on `setErrorHandler`
- update controllers to export plain async handlers
- centralize error mapping via `handleControllerError`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68544a8ee31c832980b6bc35b66c3545