### PR TITLE
Implement permission checks via profile permissions

### DIFF
--- a/src/http/controllers/permission/list-permission-controller.ts
+++ b/src/http/controllers/permission/list-permission-controller.ts
@@ -1,6 +1,7 @@
 import { makeListPermissionsService } from '@/services/@factories/permission/make-list-permissions'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export const ListPermissionController = async (
   request: FastifyRequest,
@@ -8,6 +9,9 @@ export const ListPermissionController = async (
 ) => {
   const user = request.user as UserToken
   const service = makeListPermissionsService()
-  const { permissions } = await service.execute(user)
+  const getProfileFromUserId = getProfileFromUserIdService()
+  const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+  const permissionsList = profile.permissions.map((p) => p.name)
+  const { permissions } = await service.execute({ ...user, permissions: permissionsList })
   return reply.status(200).send(permissions)
 }

--- a/src/http/controllers/role/list-role-controller.ts
+++ b/src/http/controllers/role/list-role-controller.ts
@@ -1,6 +1,7 @@
 import { makeListRolesService } from '@/services/@factories/role/make-list-roles'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export const ListRoleController = async (
   request: FastifyRequest,
@@ -8,6 +9,9 @@ export const ListRoleController = async (
 ) => {
   const user = request.user as UserToken
   const service = makeListRolesService()
-  const { roles } = await service.execute(user)
+  const getProfileFromUserId = getProfileFromUserIdService()
+  const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+  const permissions = profile.permissions.map((p) => p.name)
+  const { roles } = await service.execute({ ...user, permissions })
   return reply.status(200).send(roles)
 }

--- a/src/http/controllers/sale/list-sales-controller.ts
+++ b/src/http/controllers/sale/list-sales-controller.ts
@@ -1,6 +1,7 @@
 import { makeListSales } from '@/services/@factories/sale/make-list-sales'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export const ListSalesController = async (
   request: FastifyRequest,
@@ -8,6 +9,9 @@ export const ListSalesController = async (
 ) => {
   const service = makeListSales()
   const user = request.user as UserToken
-  const { sales } = await service.execute(user)
+  const getProfileFromUserId = getProfileFromUserIdService()
+  const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+  const permissions = profile.permissions.map((p) => p.name)
+  const { sales } = await service.execute({ ...user, permissions })
   return reply.status(200).send(sales)
 }

--- a/src/http/controllers/transaction/add-balance-transaction.ts
+++ b/src/http/controllers/transaction/add-balance-transaction.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 import { makeAddBalanceTransaction } from '@/services/@factories/transaction/make-add-balance-transaction'
 import { assertPermission } from '@/utils/permissions'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export const AddBalanceTransactionController = async (
   request: FastifyRequest,
@@ -17,7 +18,10 @@ export const AddBalanceTransactionController = async (
   const data = bodySchema.parse(request.body)
 
   if (data.affectedUserId) {
-    assertPermission(user.role, 'MANAGE_OTHER_USER_TRANSACTION')
+    const getProfileFromUserId = getProfileFromUserIdService()
+    const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+    const permissions = profile.permissions.map((p) => p.name)
+    assertPermission(permissions, 'MANAGE_OTHER_USER_TRANSACTION')
   }
 
   const receiptUrl = request.file

--- a/src/http/controllers/transaction/withdrawal-balance-transaction.ts
+++ b/src/http/controllers/transaction/withdrawal-balance-transaction.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { UserToken } from '../authenticate-controller'
 import { makeWithdrawalBalanceTransaction } from '@/services/@factories/transaction/make-withdrawal-balance-transaction'
 import { assertPermission } from '@/utils/permissions'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export const WithdrawalBalanceTransactionController = async (
   request: FastifyRequest,
@@ -17,7 +18,10 @@ export const WithdrawalBalanceTransactionController = async (
   const data = bodySchema.parse(request.body)
 
   if (data.affectedUserId) {
-    assertPermission(user.role, 'MANAGE_OTHER_USER_TRANSACTION')
+    const getProfileFromUserId = getProfileFromUserIdService()
+    const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+    const permissions = profile.permissions.map((p) => p.name)
+    assertPermission(permissions, 'MANAGE_OTHER_USER_TRANSACTION')
   }
 
   const receiptUrl = request.file

--- a/src/http/controllers/unit/list-units-controller.ts
+++ b/src/http/controllers/unit/list-units-controller.ts
@@ -1,6 +1,7 @@
 import { makeListUnitsService } from '@/services/@factories/unit/make-list-units'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { UserToken } from '../authenticate-controller'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export const ListUnitsController = async (
   request: FastifyRequest,
@@ -8,6 +9,9 @@ export const ListUnitsController = async (
 ) => {
   const service = makeListUnitsService()
   const user = request.user as UserToken
-  const { units } = await service.execute(user)
+  const getProfileFromUserId = getProfileFromUserIdService()
+  const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+  const permissions = profile.permissions.map((p) => p.name)
+  const { units } = await service.execute({ ...user, permissions })
   return reply.status(200).send(units)
 }

--- a/src/http/middlewares/verify-permission.ts
+++ b/src/http/middlewares/verify-permission.ts
@@ -1,12 +1,16 @@
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { Feature, assertPermission } from '@/utils/permissions'
 import { UserToken } from '../controllers/authenticate-controller'
+import { getProfileFromUserIdService } from '@/services/@factories/profile/get-profile-from-userId-service'
 
 export function verifyPermission(feature: Feature) {
   return async function (request: FastifyRequest, reply: FastifyReply) {
     const user = request.user as UserToken
+    const getProfileFromUserId = getProfileFromUserIdService()
+    const { profile } = await getProfileFromUserId.execute({ id: user.sub })
+    const permissions = profile.permissions.map((p) => p.name)
     try {
-      assertPermission(user.role, feature)
+      assertPermission(permissions, feature)
     } catch {
       return reply.status(403).send({ message: 'Unauthorized' })
     }

--- a/src/repositories/in-memory/in-memory-profiles-repository.ts
+++ b/src/repositories/in-memory/in-memory-profiles-repository.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto'
 import { ProfilesRepository } from '../profiles-repository'
 
 export class InMemoryProfilesRepository implements ProfilesRepository {
-  public items: (Profile & { user: Omit<User, 'password'> })[] = []
+  public items: (Profile & { user: Omit<User, 'password'>; permissions?: { id: string; name?: string }[] })[] = []
 
   async create(
     data: Prisma.ProfileUncheckedCreateInput,
@@ -25,7 +25,7 @@ export class InMemoryProfilesRepository implements ProfilesRepository {
       createdAt: new Date(),
     }
     if (permissionIds) {
-      ;(profile as any).permissions = permissionIds.map((id) => ({ id }))
+      ;(profile as any).permissions = permissionIds.map((id) => ({ id, name: id }))
     }
     const user: Omit<User, 'password'> = {
       id: data.userId,
@@ -42,14 +42,18 @@ export class InMemoryProfilesRepository implements ProfilesRepository {
 
   async findById(
     id: string,
-  ): Promise<(Profile & { user: Omit<User, 'password'> }) | null> {
-    return this.items.find((item) => item.id === id) ?? null
+  ): Promise<
+    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name?: string }[] }) | null
+  > {
+    return (this.items.find((item) => item.id === id) as any) ?? null
   }
 
   async findByUserId(
     id: string,
-  ): Promise<(Profile & { user: Omit<User, 'password'> }) | null> {
-    return this.items.find((item) => item.user.id === id) ?? null
+  ): Promise<
+    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name?: string }[] }) | null
+  > {
+    return (this.items.find((item) => item.user.id === id) as any) ?? null
   }
 
   async update(
@@ -67,8 +71,10 @@ export class InMemoryProfilesRepository implements ProfilesRepository {
     throw new ProfileNotFoundError()
   }
 
-  async findMany(): Promise<(Profile & { user: Omit<User, 'password'> })[]> {
-    return this.items
+  async findMany(): Promise<
+    (Profile & { user: Omit<User, 'password'>; permissions?: { id: string; name?: string }[] })[]
+  > {
+    return this.items as any
   }
 
   async incrementBalance(

--- a/src/repositories/prisma/prisma-profile-repository.ts
+++ b/src/repositories/prisma/prisma-profile-repository.ts
@@ -39,7 +39,9 @@ export class PrismaProfilesRepository implements ProfilesRepository {
 
   async findByUserId(
     id: string,
-  ): Promise<(Profile & { user: Omit<User, 'password'> }) | null> {
+  ): Promise<
+    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name: string }[] }) | null
+  > {
     const profile = await prisma.profile.findUnique({
       where: { userId: id },
       include: {
@@ -54,9 +56,12 @@ export class PrismaProfilesRepository implements ProfilesRepository {
             createdAt: true,
           },
         },
+        permissions: { select: { id: true, name: true } },
       },
     })
-    return profile as (Profile & { user: Omit<User, 'password'> }) | null
+    return profile as unknown as
+      | (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name: string }[] })
+      | null
   }
 
   async create(

--- a/src/repositories/profiles-repository.ts
+++ b/src/repositories/profiles-repository.ts
@@ -10,7 +10,9 @@ export interface ProfilesRepository {
   ): Promise<Profile>
   findByUserId(
     userId: string,
-  ): Promise<(Profile & { user: Omit<User, 'password'> }) | null>
+  ): Promise<
+    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name: string }[] }) | null
+  >
   update(id: string, data: Prisma.ProfileUncheckedUpdateInput): Promise<Profile>
   findMany(
     where?: Prisma.ProfileWhereInput,

--- a/src/services/permission/list-permissions.ts
+++ b/src/services/permission/list-permissions.ts
@@ -11,9 +11,9 @@ interface ListPermissionsResponse {
 export class ListPermissionsService {
   constructor(private repository: PermissionRepository) {}
 
-  async execute(user: UserToken): Promise<ListPermissionsResponse> {
+  async execute(user: UserToken & { permissions: string[] }): Promise<ListPermissionsResponse> {
     assertUser(user)
-    assertPermission(user.role, 'LIST_PERMISSIONS')
+    assertPermission(user.permissions, 'LIST_PERMISSIONS')
     const permissions = await this.repository.findMany({ unitId: user.unitId })
     return { permissions }
   }

--- a/src/services/profile/get-profile-from-userId-service.ts
+++ b/src/services/profile/get-profile-from-userId-service.ts
@@ -7,7 +7,12 @@ interface GetUserProfileServiceRequest {
 }
 
 interface GetUserProfileServiceResponse {
-  profile: (Profile & { user: Omit<User, 'password'> }) | null
+  profile:
+    | (Profile & {
+        user: Omit<User, 'password'>
+        permissions: { id: string; name: string }[]
+      })
+    | null
 }
 
 export class GetUserProfileFromUserIdService {

--- a/src/services/role/list-roles.ts
+++ b/src/services/role/list-roles.ts
@@ -11,9 +11,9 @@ interface ListRolesResponse {
 export class ListRolesService {
   constructor(private repository: RoleModelRepository) {}
 
-  async execute(user: UserToken): Promise<ListRolesResponse> {
+  async execute(user: UserToken & { permissions: string[] }): Promise<ListRolesResponse> {
     assertUser(user)
-    assertPermission(user.role, 'LIST_ROLES')
+    assertPermission(user.permissions, 'LIST_ROLES')
     const roles = await this.repository.findMany({ unitId: user.unitId })
     return { roles }
   }

--- a/src/services/sale/list-sales.ts
+++ b/src/services/sale/list-sales.ts
@@ -7,9 +7,9 @@ import { assertUser } from '@/utils/assert-user'
 export class ListSalesService {
   constructor(private repository: SaleRepository) {}
 
-  async execute(userToken: UserToken): Promise<ListSalesResponse> {
+  async execute(userToken: UserToken & { permissions: string[] }): Promise<ListSalesResponse> {
     assertUser(userToken)
-    assertPermission(userToken.role, 'LIST_SALES')
+    assertPermission(userToken.permissions, 'LIST_SALES')
     const scope = getScope(userToken)
     const where = buildUnitWhere(scope)
     const sales = await this.repository.findMany(where)

--- a/src/services/unit/list-units.ts
+++ b/src/services/unit/list-units.ts
@@ -11,14 +11,14 @@ interface ListUnitsResponse {
 export class ListUnitsService {
   constructor(private repository: UnitRepository) {}
 
-  async execute(userToken: UserToken): Promise<ListUnitsResponse> {
+  async execute(userToken: UserToken & { permissions: string[] }): Promise<ListUnitsResponse> {
     assertUser(userToken)
 
     let units: Unit[] = []
 
-    if (hasPermission(userToken.role, 'LIST_ALL_UNITS')) {
+    if (hasPermission(userToken.permissions, 'LIST_ALL_UNITS')) {
       units = await this.repository.findMany()
-    } else if (hasPermission(userToken.role, 'LIST_ORG_UNIT')) {
+    } else if (hasPermission(userToken.permissions, 'LIST_ORG_UNIT')) {
       units = await this.repository.findMany({
         organizationId: userToken.organizationId,
       })

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -3,73 +3,40 @@ import { PermissionDeniedError } from '@/services/@errors/permission/permission-
 import { UnitRepository } from '@/repositories/unit-repository'
 
 export const FEATURES = {
-  // UNIT
-  LIST_UNITS: ['ADMIN', 'OWNER', 'BARBER', 'MANAGER', 'ATTENDANT'] as Role[],
-  LIST_ALL_UNITS: ['ADMIN'] as Role[],
-  LIST_ORG_UNIT: ['OWNER', 'BARBER', 'MANAGER', 'ATTENDANT'] as Role[],
-  CREATE_UNIT: ['ADMIN'] as Role[],
-  // SERVICE
-  LIST_SERVICES: ['ADMIN', 'OWNER', 'BARBER', 'MANAGER', 'ATTENDANT'] as Role[],
-  LIST_TRANSACTIONS: [
-    'ADMIN',
-    'OWNER',
-    'BARBER',
-    'MANAGER',
-    'ATTENDANT',
-  ] as Role[],
-  // ORGANIZATION
-  LIST_ORGANIZATIONS: [
-    'ADMIN',
-    'OWNER',
-    'BARBER',
-    'MANAGER',
-    'ATTENDANT',
-  ] as Role[],
-  // PRODUCT
-  LIST_PRODUCTS: ['ADMIN', 'OWNER', 'BARBER', 'MANAGER', 'ATTENDANT'] as Role[],
-  // APPOINTMENT
-  LIST_APPOINTMENTS: [
-    'ADMIN',
-    'OWNER',
-    'BARBER',
-    'MANAGER',
-    'ATTENDANT',
-  ] as Role[],
-  // USER
-  LIST_USERS: ['ADMIN', 'OWNER', 'BARBER', 'MANAGER'] as Role[],
-  // COUPON
-  LIST_COUPONS: ['ADMIN', 'OWNER', 'BARBER', 'MANAGER', 'ATTENDANT'] as Role[],
-  // CASH
-  LIST_CASH_SESSIONS: [
-    'ADMIN',
-    'OWNER',
-    'BARBER',
-    'MANAGER',
-    'ATTENDANT',
-  ] as Role[],
-  // SALE
-  LIST_SALES: ['ADMIN', 'OWNER', 'BARBER', 'MANAGER', 'ATTENDANT'] as Role[],
-  // TRANSACTION
-  MANAGE_USER_TRANSACTION_WITHDRAWAL: [
-    'ADMIN',
-    'OWNER',
-    'MANAGER',
-    'BARBER',
-  ] as Role[],
-  MANAGE_USER_TRANSACTION_ADD: ['ADMIN', 'OWNER', 'MANAGER'] as Role[],
-  MANAGE_OTHER_USER_TRANSACTION: ['ADMIN', 'OWNER', 'MANAGER'] as Role[],
-  LIST_ROLES: ['OWNER'] as Role[],
-  LIST_PERMISSIONS: ['MANAGER'] as Role[],
+  LIST_UNITS: ['LIST_UNITS'],
+  LIST_ALL_UNITS: ['LIST_ALL_UNITS'],
+  LIST_ORG_UNIT: ['LIST_ORG_UNIT'],
+  CREATE_UNIT: ['CREATE_UNIT'],
+  LIST_SERVICES: ['LIST_SERVICES'],
+  LIST_TRANSACTIONS: ['LIST_TRANSACTIONS'],
+  LIST_ORGANIZATIONS: ['LIST_ORGANIZATIONS'],
+  LIST_PRODUCTS: ['LIST_PRODUCTS'],
+  LIST_APPOINTMENTS: ['LIST_APPOINTMENTS'],
+  LIST_USERS: ['LIST_USERS'],
+  LIST_COUPONS: ['LIST_COUPONS'],
+  LIST_CASH_SESSIONS: ['LIST_CASH_SESSIONS'],
+  LIST_SALES: ['LIST_SALES'],
+  MANAGE_USER_TRANSACTION_WITHDRAWAL: ['MANAGE_USER_TRANSACTION_WITHDRAWAL'],
+  MANAGE_USER_TRANSACTION_ADD: ['MANAGE_USER_TRANSACTION_ADD'],
+  MANAGE_OTHER_USER_TRANSACTION: ['MANAGE_OTHER_USER_TRANSACTION'],
+  LIST_ROLES: ['LIST_ROLES'],
+  LIST_PERMISSIONS: ['LIST_PERMISSIONS'],
 } as const
 
 export type Feature = keyof typeof FEATURES
 
-export function hasPermission(role: Role, feature: Feature): boolean {
-  return FEATURES[feature].includes(role)
+export function hasPermission(
+  permissions: string[],
+  feature: Feature,
+): boolean {
+  return FEATURES[feature].some((p) => permissions.includes(p))
 }
 
-export function assertPermission(role: Role, feature: Feature): void {
-  if (!hasPermission(role, feature)) {
+export function assertPermission(
+  permissions: string[],
+  feature: Feature,
+): void {
+  if (!hasPermission(permissions, feature)) {
     throw new PermissionDeniedError()
   }
 }

--- a/test/tests/permission/list-permissions.spec.ts
+++ b/test/tests/permission/list-permissions.spec.ts
@@ -21,6 +21,7 @@ describe('List permissions service', () => {
       role: 'MANAGER',
       unitId: 'unit-1',
       organizationId: 'org-1',
+      permissions: ['LIST_PERMISSIONS'],
     } as any)
     expect(res.permissions).toHaveLength(1)
     expect(res.permissions[0].id).toBe('p1')

--- a/test/tests/role/list-roles.spec.ts
+++ b/test/tests/role/list-roles.spec.ts
@@ -21,6 +21,7 @@ describe('List roles service', () => {
       role: 'OWNER',
       unitId: 'unit-1',
       organizationId: 'org-1',
+      permissions: ['LIST_ROLES'],
     } as any)
     expect(res.roles).toHaveLength(1)
     expect(res.roles[0].id).toBe('r1')

--- a/test/tests/sale/list-sales.spec.ts
+++ b/test/tests/sale/list-sales.spec.ts
@@ -22,6 +22,7 @@ describe('List sales service', () => {
       role: 'ADMIN',
       unitId: 'unit-1',
       organizationId: 'org-1',
+      permissions: ['LIST_SALES'],
     } as any)
     expect(res.sales).toHaveLength(2)
   })
@@ -32,6 +33,7 @@ describe('List sales service', () => {
       role: 'OWNER',
       unitId: 'unit-1',
       organizationId: 'org-1',
+      permissions: ['LIST_SALES'],
     } as any)
     expect(res.sales).toHaveLength(1)
     expect(res.sales[0].id).toBe('s1')
@@ -43,6 +45,7 @@ describe('List sales service', () => {
       role: 'BARBER',
       unitId: 'unit-2',
       organizationId: 'org-2',
+      permissions: ['LIST_SALES'],
     } as any)
     expect(res.sales).toHaveLength(1)
     expect(res.sales[0].id).toBe('s2')
@@ -55,6 +58,7 @@ describe('List sales service', () => {
         role: 'ADMIN',
         unitId: 'unit-1',
         organizationId: 'org-1',
+        permissions: ['LIST_SALES'],
       } as any),
     ).rejects.toThrow('User not found')
   })

--- a/test/tests/unit/list-units.spec.ts
+++ b/test/tests/unit/list-units.spec.ts
@@ -21,6 +21,7 @@ describe('List units service', () => {
       role: 'ADMIN',
       organizationId: 'org-1',
       unitId: 'unit-1',
+      permissions: ['LIST_ALL_UNITS'],
     } as any)
     expect(result.units).toHaveLength(2)
   })
@@ -31,6 +32,7 @@ describe('List units service', () => {
       role: 'BARBER',
       organizationId: 'org-1',
       unitId: 'unit-1',
+      permissions: ['LIST_ORG_UNIT'],
     } as any)
     expect(result.units).toHaveLength(2)
     expect(result.units[0].id).toBe('unit-1')
@@ -42,6 +44,7 @@ describe('List units service', () => {
       role: 'MANAGER',
       organizationId: 'org-1',
       unitId: 'unit-1',
+      permissions: ['LIST_ORG_UNIT'],
     } as any)
     expect(result.units).toHaveLength(2)
     expect(result.units[0].id).toBe('unit-1')
@@ -54,6 +57,7 @@ describe('List units service', () => {
         role: 'ADMIN',
         organizationId: 'org-1',
         unitId: 'unit-1',
+        permissions: ['LIST_ALL_UNITS'],
       } as any),
     ).rejects.toThrow('User not found')
   })


### PR DESCRIPTION
## Summary
- refactor permissions util to accept permission arrays
- fetch profile permissions in permission middleware and controllers
- update repository methods to include permissions
- adjust services and tests to use new permission lists

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: cannot find type declarations)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e24103708329819abf4d57324483