### PR TITLE
Fix lint warnings

### DIFF
--- a/src/repositories/in-memory/in-memory-barber-users-repository.ts
+++ b/src/repositories/in-memory/in-memory-barber-users-repository.ts
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto'
 export class InMemoryBarberUsersRepository implements BarberUsersRepository {
   constructor(
     public users: (User & {
-      profile: Profile | null
+      profile: (Profile & { permissions: { id: string }[] }) | null
       unit?: Unit | null
     })[] = [],
   ) {}
@@ -26,7 +26,7 @@ export class InMemoryBarberUsersRepository implements BarberUsersRepository {
       unitId: (data.unit as { connect: { id: string } }).connect.id,
       createdAt: new Date(),
     }
-    const profile: Profile & { permissions?: { id: string }[] } = {
+    const profile: Profile & { permissions: { id: string }[] } = {
       id: randomUUID(),
       userId: user.id,
       phone: profileData.phone as string,
@@ -41,9 +41,7 @@ export class InMemoryBarberUsersRepository implements BarberUsersRepository {
           .commissionPercentage ?? 100,
       totalBalance: 0,
       createdAt: new Date(),
-    }
-    if (permissionIds) {
-      profile.permissions = permissionIds.map((id) => ({ id }))
+      permissions: permissionIds?.map((id) => ({ id })) ?? [],
     }
     this.users.push({
       ...user,
@@ -100,7 +98,7 @@ export class InMemoryBarberUsersRepository implements BarberUsersRepository {
         profile.commissionPercentage =
           profileData.commissionPercentage as number
       if (permissionIds) {
-        ;(profile as any).permissions = permissionIds.map((id) => ({ id }))
+        profile.permissions = permissionIds.map((id) => ({ id }))
       }
     }
     this.users[index] = { ...current, ...updatedUser, profile }

--- a/src/repositories/in-memory/in-memory-permission-repository.ts
+++ b/src/repositories/in-memory/in-memory-permission-repository.ts
@@ -3,7 +3,9 @@ import { randomUUID } from 'crypto'
 import { PermissionRepository } from '../permission-repository'
 
 export class InMemoryPermissionRepository implements PermissionRepository {
-  constructor(public permissions: Permission[] = []) {}
+  constructor(
+    public permissions: (Permission & { roles?: { id: string }[] })[] = [],
+  ) {}
 
   async create(data: Prisma.PermissionCreateInput): Promise<Permission> {
     const permission: Permission = {
@@ -26,7 +28,7 @@ export class InMemoryPermissionRepository implements PermissionRepository {
 
   async findManyByRole(roleModelId: string): Promise<Permission[]> {
     return this.permissions.filter((p) =>
-      (p as any).roles?.some((r: any) => r.id === roleModelId),
+      p.roles?.some((r) => r.id === roleModelId),
     )
   }
 

--- a/src/repositories/in-memory/in-memory-profiles-repository.ts
+++ b/src/repositories/in-memory/in-memory-profiles-repository.ts
@@ -4,13 +4,16 @@ import crypto from 'node:crypto'
 import { ProfilesRepository } from '../profiles-repository'
 
 export class InMemoryProfilesRepository implements ProfilesRepository {
-  public items: (Profile & { user: Omit<User, 'password'>; permissions?: { id: string; name?: string }[] })[] = []
+  public items: (Profile & {
+    user: Omit<User, 'password'>
+    permissions: { id: string; name: string }[]
+  })[] = []
 
   async create(
     data: Prisma.ProfileUncheckedCreateInput,
     permissionIds?: string[],
   ): Promise<Profile> {
-    const profile: Profile = {
+    const profile: Profile & { permissions: { id: string; name: string }[] } = {
       id: crypto.randomUUID(),
       phone: data.phone,
       cpf: data.cpf,
@@ -23,9 +26,7 @@ export class InMemoryProfilesRepository implements ProfilesRepository {
       totalBalance: 0,
       userId: data.userId,
       createdAt: new Date(),
-    }
-    if (permissionIds) {
-      ;(profile as any).permissions = permissionIds.map((id) => ({ id, name: id }))
+      permissions: permissionIds?.map((id) => ({ id, name: id })) ?? [],
     }
     const user: Omit<User, 'password'> = {
       id: data.userId,
@@ -40,20 +41,26 @@ export class InMemoryProfilesRepository implements ProfilesRepository {
     return profile
   }
 
-  async findById(
-    id: string,
-  ): Promise<
-    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name?: string }[] }) | null
+  async findById(id: string): Promise<
+    | (Profile & {
+        user: Omit<User, 'password'>
+        permissions: { id: string; name: string }[]
+      })
+    | null
   > {
-    return (this.items.find((item) => item.id === id) as any) ?? null
+    const profile = this.items.find((item) => item.id === id)
+    return profile ?? null
   }
 
-  async findByUserId(
-    id: string,
-  ): Promise<
-    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name?: string }[] }) | null
+  async findByUserId(id: string): Promise<
+    | (Profile & {
+        user: Omit<User, 'password'>
+        permissions: { id: string; name: string }[]
+      })
+    | null
   > {
-    return (this.items.find((item) => item.user.id === id) as any) ?? null
+    const profile = this.items.find((item) => item.user.id === id)
+    return profile ?? null
   }
 
   async update(
@@ -72,9 +79,12 @@ export class InMemoryProfilesRepository implements ProfilesRepository {
   }
 
   async findMany(): Promise<
-    (Profile & { user: Omit<User, 'password'>; permissions?: { id: string; name?: string }[] })[]
+    (Profile & {
+      user: Omit<User, 'password'>
+      permissions: { id: string; name: string }[]
+    })[]
   > {
-    return this.items as any
+    return this.items
   }
 
   async incrementBalance(

--- a/src/repositories/prisma/prisma-profile-repository.ts
+++ b/src/repositories/prisma/prisma-profile-repository.ts
@@ -37,10 +37,12 @@ export class PrismaProfilesRepository implements ProfilesRepository {
     return profile as (Profile & { user: Omit<User, 'password'> }) | null
   }
 
-  async findByUserId(
-    id: string,
-  ): Promise<
-    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name: string }[] }) | null
+  async findByUserId(id: string): Promise<
+    | (Profile & {
+        user: Omit<User, 'password'>
+        permissions: { id: string; name: string }[]
+      })
+    | null
   > {
     const profile = await prisma.profile.findUnique({
       where: { userId: id },
@@ -60,7 +62,10 @@ export class PrismaProfilesRepository implements ProfilesRepository {
       },
     })
     return profile as unknown as
-      | (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name: string }[] })
+      | (Profile & {
+          user: Omit<User, 'password'>
+          permissions: { id: string; name: string }[]
+        })
       | null
   }
 

--- a/src/repositories/profiles-repository.ts
+++ b/src/repositories/profiles-repository.ts
@@ -8,10 +8,12 @@ export interface ProfilesRepository {
     data: Prisma.ProfileUncheckedCreateInput,
     permissionIds?: string[],
   ): Promise<Profile>
-  findByUserId(
-    userId: string,
-  ): Promise<
-    (Profile & { user: Omit<User, 'password'>; permissions: { id: string; name: string }[] }) | null
+  findByUserId(userId: string): Promise<
+    | (Profile & {
+        user: Omit<User, 'password'>
+        permissions: { id: string; name: string }[]
+      })
+    | null
   >
   update(id: string, data: Prisma.ProfileUncheckedUpdateInput): Promise<Profile>
   findMany(

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -29,7 +29,7 @@ export type Feature = keyof typeof FEATURES
 async function getPermissionsFromUserId(userId: string): Promise<string[]> {
   const service = getProfileFromUserIdService()
   const { profile } = await service.execute({ id: userId })
-  return profile.permissions.map((p) => p.name)
+  return profile ? profile.permissions.map((p) => p.name) : []
 }
 
 export async function hasPermission(

--- a/test/helpers/fake-repositories.ts
+++ b/test/helpers/fake-repositories.ts
@@ -15,10 +15,36 @@ export { InMemoryTransactionRepository as FakeTransactionRepository } from '../.
 export { InMemoryOrganizationRepository as FakeOrganizationRepository } from '../../src/repositories/in-memory/in-memory-organization-repository'
 
 export class FakeProfilesRepository extends InMemoryProfilesRepository {
+  private _profiles: (Profile & {
+    user: Omit<User, 'password'>
+    permissions: { id: string; name: string }[]
+  })[] = []
+
   constructor(
-    public profiles: (Profile & { user: Omit<User, 'password'> })[] = [],
+    profiles: (Profile & {
+      user: Omit<User, 'password'>
+      permissions: { id: string; name: string }[]
+    })[] = [],
   ) {
     super()
+    this._profiles = profiles
+    this.items = profiles
+  }
+
+  get profiles(): (Profile & {
+    user: Omit<User, 'password'>
+    permissions: { id: string; name: string }[]
+  })[] {
+    return this._profiles
+  }
+
+  set profiles(
+    profiles: (Profile & {
+      user: Omit<User, 'password'>
+      permissions: { id: string; name: string }[]
+    })[],
+  ) {
+    this._profiles = profiles
     this.items = profiles
   }
 }


### PR DESCRIPTION
## Summary
- eliminate any casts and enforce explicit types in in-memory repositories
- ensure permission checks don't rely on non-null assertions
- keep fake repositories in sync with stricter types

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855731df1388329b12ed9ea8b056884